### PR TITLE
More readeable version for the realPath

### DIFF
--- a/np.sh
+++ b/np.sh
@@ -15,9 +15,9 @@ if test "0" != "$(git rev-list --count --left-only @'{u}'...HEAD)"; then
 	exit 128;
 fi
 
-trashCli=$(node -e "var path = require('path');console.log(path.join(path.dirname(require('fs').realpathSync('$0')), 'node_modules/.bin/trash'))");
+realPath=$(node -e "console.log(require('path').dirname(require('fs').realpathSync('$0')))")
 
-node "$trashCli" node_modules &&
+$realPath/node_modules/.bin/trash node_modules &&
 npm install &&
 npm test &&
 npm version ${1:-patch} &&


### PR DESCRIPTION
This make it easier to read and make the minimal require code in node, which make sense to me since we are in a bash script.
And make `realPath` reusable if needed.