### PR TITLE
test with only `dependencies` to prevent wrongly placed dependencies …

### DIFF
--- a/np.sh
+++ b/np.sh
@@ -18,8 +18,9 @@ fi
 trashCli=$(node -e "var path = require('path');console.log(path.join(path.dirname(require('fs').realpathSync('$0')), 'node_modules/.bin/trash'))");
 
 node "$trashCli" node_modules &&
-npm install &&
+npm install --production &&
 npm test &&
 npm version ${1:-patch} &&
 npm publish &&
-git push --follow-tags
+git push --follow-tags &&
+(npm install --silent --no-spin >/dev/null &) # get devDependencies back in the background


### PR DESCRIPTION
…to not be caught

then install the devDependencies at the end in the background

Like in the https://github.com/sindresorhus/grunt-concurrent/pull/85 case.