### PR TITLE
Use Node's require.resolve to resolve trash binary, to make local installs work properly

### DIFF
--- a/np.sh
+++ b/np.sh
@@ -15,7 +15,7 @@ if test "0" != "$(git rev-list --count --left-only @'{u}'...HEAD)"; then
 	exit 128;
 fi
 
-trashCli=$(node -e "console.log(require.resolve('.bin/trash'))");
+trashCli=$(node -p "require.resolve('.bin/trash')");
 
 node "$trashCli" node_modules &&
 npm install &&

--- a/np.sh
+++ b/np.sh
@@ -15,7 +15,7 @@ if test "0" != "$(git rev-list --count --left-only @'{u}'...HEAD)"; then
 	exit 128;
 fi
 
-trashCli=$(node -e "var path = require('path');console.log(path.join(path.dirname(require('fs').realpathSync('$0')), 'node_modules/.bin/trash'))");
+trashCli=$(node -e "console.log(require.resolve('.bin/trash'))");
 
 node "$trashCli" node_modules &&
 npm install &&


### PR DESCRIPTION
I quite like to install local dependencies, rather than globals, and run things through NPM scripts, so a single NPM install neatly manages every build tool required for a project. Currently though you can't install and run np locally within a project, it only works globally.

If you do install it locally atm, the current $trashCli logic (for me on OSX) resolves to "/Users/.../PROJECT_ROOT/node_modules/np/node_modules/.bin/trash", which doesn't exist (it should be PROJECT_ROOT/node_modules/.bin/trash). This patch's logic delegates this instead to require.resolve, which follows the relevant .bin/trash link and finds the correct binary.

For me with a local install this now returns "/Users/.../PROJECT_ROOT/node_modules/trash-cli/cli.js", or globally "/usr/local/lib/node_modules/np/node_modules/trash-cli/cli.js", so is correct in both cases.

I've only tested this myself with Node v5.11.0/NPM 3.8.6, but I strongly suspect require.resolve should be able to handle this way back to the dawn of time.