### PR TITLE
check if running node 6 - fixes #20

### DIFF
--- a/np.sh
+++ b/np.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env sh
 
+if test "$(node -v | sed -e "s#v\([0-9]*\)\.[0-9]*\.[0-9]*#\1#")" == "6"; then
+	echo 'You should not publish when running Node.js 6. Please downgrade and publish again. https://github.com/npm/npm/issues/5082' >&2;
+	exit 128;
+fi
+
 if test -n "$(git status --porcelain)"; then
 	echo 'Unclean working tree. Commit or stash changes first.' >&2;
 	exit 128;


### PR DESCRIPTION
This check tests if the major version of `node -v` is `6` because of the publish bug. If that is the case, it is logged and the process exits. This fixes #20 .

`sed` doesn't support non-greedy operators so I had to use a longer version.