### PR TITLE
Ensure current branch is master

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,12 +8,15 @@ const cli = meow(`
 	Usage
 	  $ np [patch | minor | major | <version>] (Default: patch)
 
+	Option
+	  --any-branch  Allow publishing from any branch
+
 	Example
 	  $ np patch
 `);
 
 try {
-	np(cli.input[0]);
+	np(cli.input[0], cli.flags);
 } catch (err) {
 	console.error(` ${logSymbols.error} ${err.message}`);
 	process.exit(1);

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const exec = (cmd, args) => {
 	}
 };
 
-module.exports = input => {
+module.exports = (input, opts) => {
 	input = input || 'patch';
 
 	if (['patch', 'minor', 'major'].indexOf(input) === -1 && !semver.valid(input)) {
@@ -29,6 +29,10 @@ module.exports = input => {
 
 	if (semver.gte(process.version, '6.0.0')) {
 		throw new Error('You should not publish when running Node.js 6. Please downgrade and publish again. https://github.com/npm/npm/issues/5082');
+	}
+
+	if (!opts.anyBranch && execa.sync('git', ['symbolic-ref', '--short', 'HEAD']).stdout !== 'master') {
+		throw new Error('Not on `master` branch. Use --any-branch to publish anyway.');
 	}
 
 	if (execa.sync('git', ['status', '--porcelain']).stdout !== '') {

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@
 
 ## Why
 
+- Ensures you are publishing from the `master` branch
 - Ensures the working directory is clean and that there are no unpulled changes
 - Reinstalls dependencies to ensure your project works with the latest dependency tree
 - Runs the tests
@@ -27,6 +28,9 @@ $ np --help
 
   Usage
     $ np [patch | minor | major | <version>] (Default: patch)
+
+  Option
+    --any-branch  Allow publishing from any branch
 
   Example
     $ np patch


### PR DESCRIPTION
This PR attempts to protect the user against accidentally publishing from a feature branch, as mentioned in #26.

Some notes:
 - I have [sholladay/branch-name](https://github.com/sholladay/branch-name) which is meant for stuff like this. I put a lot of research into the various techniques for detecting the current branch and their edge cases. But wrapping the other sync git code in a `.then()` seems a bit silly. Anyway, it's there if you want it. For now, I just copied over the important bits.
 - I hardcoded the syntax for the CLI override into the API's error message. Not ideal, but probably not important. Happy to do it another way.