### PR TITLE
Use npm-publish-safe-latest to avoid bumping the latest dist-tag on pre-release versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = (input, opts) => {
 		},
 		{
 			title: 'Publishing package',
-			task: () => exec('npm', ['publish'])
+			task: () => exec('npm-publish-safe-latest')
 		},
 		{
 			title: 'Pushing tags',

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "execa": "^0.4.0",
     "listr": "^0.4.3",
     "meow": "^3.7.0",
+    "npm-publish-safe-latest": "^1.1.4",
     "pify": "^2.3.0",
     "rxjs": "^5.0.0-beta.9",
     "semver": "^5.1.0",

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@
 - Runs the tests
 - Bumps the version in package.json and creates a git tag
 - Publishes the new version to npm
+- Doesn't set the npm `dist-tag` to `latest` when publishing pre-release versions
 - Pushes commits and tags to GitHub
 
 


### PR DESCRIPTION
Hello, I stumbled across this package and it's great!  This PR adds [`npm-publish-safe-latest`](https://github.com/scott113341/npm-publish-safe-latest), which is a module I wrote that has a safer opinion about how npm handles the `dist-tag` when publishing.  

By default, npm will set the `dist-tag` to `latest` when you publish a module, even if you're publishing a pre-release version like `v2.0.0-0` or `v2.0.0-rc1`.  This is pretty dangerous since anyone who runs `npm install your-package` will get a potentially unstable/undocumented/unusable version of `your-package`.  I have [opened an issue](https://github.com/npm/npm/issues/13248) with npm, but this might be a worthy addition to `np` regardless.  I haven't received a reply from the npm team yet, but they've added the "footgun" tag to the issue, which indicates that at least someone agrees that this is an easy way to shoot yourself in the foot! 👣 🔫 

When using `npm-publish-safe-latest`, the `dist-tag` is set to `pre-release` if a pre-release version is being published.  Otherwise, the default tag (usually `latest`) is used.

I hope you find this useful.  Cheers!