### PR TITLE
Add --tag option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,11 +12,13 @@ const cli = meow(`
 	  --any-branch    Allow publishing from any branch
 	  --skip-cleanup  Skips cleanup of node_modules
 	  --yolo          Skips cleanup and testing
+	  --tag           Publish under a given dist-tag
 
 	Examples
 	  $ np
 	  $ np patch
 	  $ np 1.0.2
+	  $ np 1.0.2-beta.3 --tag beta
 `);
 
 updateNotifier({pkg: cli.pkg}).notify();

--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,7 @@ const cli = meow(`
 	  $ np
 	  $ np patch
 	  $ np 1.0.2
-	  $ np 1.0.2-beta.3 --tag beta
+	  $ np 1.0.2-beta.3 --tag=beta
 `);
 
 updateNotifier({pkg: cli.pkg}).notify();

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = (input, opts) => {
 		},
 		{
 			title: 'Publishing package',
-			task: () => exec('npm', ['publish'])
+			task: () => exec('npm', ['publish'].concat(opts.tag ? ['--tag', opts.tag] : []))
 		},
 		{
 			title: 'Pushing tags',

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ $ np --help
     $ np
     $ np major
     $ np 1.0.2
-    $ np 1.0.2-beta.3 --tag beta
+    $ np 1.0.2-beta.3 --tag=beta
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@
 - Reinstalls dependencies to ensure your project works with the latest dependency tree
 - Runs the tests
 - Bumps the version in package.json and creates a git tag
-- Publishes the new version to npm
+- Publishes the new version to npm, optionally under a [dist-tag](https://docs.npmjs.com/cli/dist-tag)
 - Pushes commits and tags to GitHub
 
 
@@ -35,11 +35,13 @@ $ np --help
     --any-branch    Allow publishing from any branch
     --skip-cleanup  Skips cleanup of node_modules
     --yolo          Skips cleanup and testing
+    --tag           Publish under a given dist-tag
 
   Examples
     $ np
     $ np major
     $ np 1.0.2
+    $ np 1.0.2-beta.3 --tag beta
 ```
 
 


### PR DESCRIPTION
Publish Add support for `--tag xx`, which publishes under a given dist-tag. Closes #45.