### PR TITLE
Use listr skip API to skip publishing private packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,13 +114,12 @@ module.exports = (input, opts) => {
 		},
 		{
 			title: 'Publishing package',
-			task: () => {
+			skip: () => {
 				if (readPkgUp.sync().pkg.private) {
-					return 'Private package: publishing skipped.';
+					return 'Private package: not publishing to npm.';
 				}
-
-				return exec('npm', ['publish'].concat(opts.tag ? ['--tag', opts.tag] : []));
-			}
+			},
+			task: () => exec('npm', ['publish'].concat(opts.tag ? ['--tag', opts.tag] : []))
 		},
 		{
 			title: 'Pushing tags',

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "any-observable": "^0.2.0",
     "del": "^2.2.0",
     "execa": "^0.4.0",
-    "listr": "^0.4.3",
+    "listr": "^0.5.0",
     "meow": "^3.7.0",
     "read-pkg-up": "^1.0.1",
     "rxjs": "^5.0.0-beta.9",


### PR DESCRIPTION
![skipping](https://media.giphy.com/media/ZOuN4VxtpjeUw/giphy.gif)

Fixes #69.

Just waiting for a new version of listr to be published then I can bump the version.