### PR TITLE
add git tag check - fixes #70

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,11 @@ const prerequisiteTasks = newVersion => {
 							throw new Error(`Git tag \`v${newVersion}\` already exists.`);
 						}
 					},
-					() => { }
+					err => {
+						if (err.stdout !== '' || err.stderr !== '') {
+							throw err;
+						}
+					}
 				)
 		}
 	]);

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const exec = (cmd, args) => {
 };
 
 const prerequisiteCheckTasks = (input, pkg, opts) => {
-	const newVersion = VERSIONS.indexOf(input) ? semver.inc(pkg.version, input) : input;
+	const newVersion = VERSIONS.indexOf(input) === -1 ? input : semver.inc(pkg.version, input);
 
 	const tasks = [
 		{
@@ -33,7 +33,7 @@ const prerequisiteCheckTasks = (input, pkg, opts) => {
 					return Promise.reject(new Error(`Version should be either ${VERSIONS.join(', ')}, or a valid semver version.`));
 				}
 
-				if (semver.lte(pkg.version, newVersion)) {
+				if (semver.gte(pkg.version, newVersion)) {
 					return Promise.reject(new Error(`New version \`${newVersion}\` should be higher than current version \`${pkg.version}\``));
 				}
 			}

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ const prerequisiteTasks = newVersion => {
 			task: () => execa('git', ['fetch'])
 		},
 		{
-			title: 'Check git tag existance',
+			title: 'Check git tag existence',
 			task: () => execa.stdout('git', ['rev-parse', '--quiet', '--verify', `refs/tags/v${newVersion}`])
 				.then(
 					output => {

--- a/test.js
+++ b/test.js
@@ -13,6 +13,11 @@ test('version is pre-release', t => {
 	t.throws(m('preminor'), message);
 	t.throws(m('prepatch'), message);
 	t.throws(m('prerelease'), message);
-	t.throws(m('1.0.0-0'), message);
-	t.throws(m('1.0.0-beta'), message);
+	t.throws(m('10.0.0-0'), message);
+	t.throws(m('10.0.0-beta'), message);
+});
+
+test('foo', t => {
+	t.throws(m('1.0.0'), 'New version `1.0.0` should be higher than current version `2.8.0`');
+	t.throws(m('1.0.0-beta'), 'New version `1.0.0-beta` should be higher than current version `2.8.0`');
 });


### PR DESCRIPTION
Tried to implement #70.

### What changed?

Extracted the prerequisite check into a separate subtask list with the following tasks

1. Check Node.js and npm version
    - This task will be skipped if Node.js is < 6. Or should we keep the previous logic without `skip` function?
2. Fetch remote changes (necessary to be executed before 3 but doesn't feel right in this place)
3. Check git tag existance
    - I execute the command `git rev-parse --quiet --verify refs/tags/NEW_TAG`. Anything else I should use?

Feedback is more then welcome because I'm not totally sure about the implementation.

// @sindresorhus @jamestalmage @ianstormtaylor