### PR TITLE
Specify --force with npm version to skip dirty check

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,8 @@ module.exports = (input, opts) => {
 	tasks.add([
 		{
 			title: 'Bumping version',
-			task: () => exec('npm', ['version', input])
+			// Specify --force flag to version even if the working directory is clean - np already does a dirty check anyway
+			task: () => exec('npm', ['version', input, '--force'])
 		},
 		{
 			title: 'Publishing package',

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ module.exports = (input, opts) => {
 	tasks.add([
 		{
 			title: 'Bumping version',
-			// Specify --force flag to version even if the working directory is clean - np already does a dirty check anyway
+			// Specify --force flag to proceed even if the working directory is dirty as np already does a dirty check anyway
 			task: () => exec('npm', ['version', input, '--force'])
 		},
 		{


### PR DESCRIPTION
![use the force](https://media.giphy.com/media/ues7jVBaTr1Re/giphy.gif)

`np` already does a dirty check so any changes were likely caused by doing a clean build prior to `npm version` and these files can be staged with a "version" npm run script and included in the version bump commit.

Fixes #75.