### PR TITLE
split out some tasks into separate files and some other tweaks

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,0 +1,38 @@
+'use strict';
+const execa = require('execa');
+const Listr = require('listr');
+
+module.exports = opts => {
+	const tasks = [
+		{
+			title: 'Check current branch',
+			task: () => execa.stdout('git', ['symbolic-ref', '--short', 'HEAD']).then(branch => {
+				if (branch !== 'master') {
+					throw new Error('Not on `master` branch. Use --any-branch to publish anyway.');
+				}
+			})
+		},
+		{
+			title: 'Check local working tree',
+			task: () => execa.stdout('git', ['status', '--porcelain']).then(status => {
+				if (status !== '') {
+					throw new Error('Unclean working tree. Commit or stash changes first.');
+				}
+			})
+		},
+		{
+			title: 'Check remote history',
+			task: () => execa.stdout('git', ['rev-list', '--count', '--left-only', '@{u}...HEAD']).then(result => {
+				if (result !== '0') {
+					throw new Error('Remote history differ. Please pull changes.');
+				}
+			})
+		}
+	];
+
+	if (opts.anyBranch) {
+		tasks.shift();
+	}
+
+	return new Listr(tasks);
+};

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -1,0 +1,65 @@
+'use strict';
+const semver = require('semver');
+const execa = require('execa');
+const Listr = require('listr');
+
+const VERSIONS = ['major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease'];
+const PRERELEASE_VERSIONS = ['premajor', 'preminor', 'prepatch', 'prerelease'];
+
+module.exports = (input, pkg, opts) => {
+	const newVersion = VERSIONS.indexOf(input) === -1 ? input : semver.inc(pkg.version, input);
+
+	const tasks = [
+		{
+			title: 'Validate version',
+			task: () => {
+				if (VERSIONS.indexOf(input) === -1 && !semver.valid(input)) {
+					throw new Error(`Version should be either ${VERSIONS.join(', ')}, or a valid semver version.`);
+				}
+
+				if (semver.gte(pkg.version, newVersion)) {
+					throw new Error(`New version \`${newVersion}\` should be higher than current version \`${pkg.version}\``);
+				}
+			}
+		},
+		{
+			title: 'Check for pre-release version',
+			task: () => {
+				if ((PRERELEASE_VERSIONS.indexOf(input) !== -1 || semver.prerelease(input)) && !opts.tag) {
+					throw new Error('You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag');
+				}
+			}
+		},
+		{
+			title: 'Check npm version',
+			skip: () => semver.lt(process.version, '6.0.0'),
+			task: () => execa.stdout('npm', ['version', '--json']).then(json => {
+				const versions = JSON.parse(json);
+				if (!semver.satisfies(versions.npm, '>=2.15.8 <3.0.0 || >=3.10.1')) {
+					throw new Error(`npm@${versions.npm} has known issues publishing when running Node.js 6. Please upgrade npm or downgrade Node and publish again. https://github.com/npm/npm/issues/5082`);
+				}
+			})
+		},
+		{
+			title: 'Check git tag existence',
+			task: () => execa('git', ['fetch'])
+				.then(() => execa.stdout('git', ['rev-parse', '--quiet', '--verify', `refs/tags/v${newVersion}`]))
+				.then(
+					output => {
+						if (output) {
+							throw new Error(`Git tag \`v${newVersion}\` already exists.`);
+						}
+					},
+					err => {
+						// Command fails with code 1 and no output if the tag does not exist, even though `--quiet` is provided
+						// https://github.com/sindresorhus/np/pull/73#discussion_r72385685
+						if (err.stdout !== '' || err.stderr !== '') {
+							throw err;
+						}
+					}
+				)
+		}
+	];
+
+	return new Listr(tasks);
+};


### PR DESCRIPTION
Did some tweaks. Also used `skip` to test the npm version. If the node version is less then 6.0.0, that check is marked as skipped.

Wanted to extract the `git` and `prerequisite` tasks in separate files (e.g. `lib/git.js` and `lib/prerequisite.js`). Currently the codebase looks "complex", although it is all pretty straightforward. I believe by extracting those in separate files, it will look cleaner. I can do it in this PR or we can discuss it in a separate issue if you want.