### PR TITLE
:arrow_up: listr@0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "any-observable": "^0.2.0",
     "del": "^2.2.0",
     "execa": "^0.4.0",
-    "listr": "^0.5.0",
+    "listr": "^0.6.1",
     "meow": "^3.7.0",
     "read-pkg-up": "^1.0.1",
     "rxjs": "^5.0.0-beta.9",


### PR DESCRIPTION
Since version `0.6.x`, listr supports custom renderers. Nothing improved for `np` directly, but it would be nice if I could verify everything is working correctly with `np` :). It could also help to fix GPG password prompt #79.

I linked this version of `listr` locally to `np` and ran it a couple of times. Everything seems to be working as it was.

Feel free to close the issue if you don't see direct impact on this project.