### PR TITLE
Add interactive UI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,7 @@
 const meow = require('meow');
 const updateNotifier = require('update-notifier');
 const version = require('./lib/version');
-const interactiveui = require('./lib/interactiveui');
+const ui = require('./lib/ui');
 const np = require('./');
 
 const cli = meow(`
@@ -31,13 +31,13 @@ updateNotifier({pkg: cli.pkg}).notify();
 Promise
 	.resolve()
 	.then(() => {
-		if (cli.input.length) {
+		if (cli.input.length !== 0) {
 			return Object.assign({}, cli.flags, {
 				confirm: true,
 				version: cli.input[0]
 			});
 		}
-		return interactiveui(cli.flags);
+		return ui(cli.flags);
 	})
 	.then(options => {
 		if (!options.confirm) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 const del = require('del');
 const Listr = require('listr');
 const split = require('split');
-require('any-observable/register/rxjs-all');
+require('any-observable/register/rxjs-all'); // eslint-disable-line import/no-unassigned-import
 const Observable = require('any-observable');
 const streamToObservable = require('stream-to-observable');
 const readPkgUp = require('read-pkg-up');

--- a/lib/interactiveui.js
+++ b/lib/interactiveui.js
@@ -1,0 +1,106 @@
+'use strict';
+const execa = require('execa');
+const inquirer = require('inquirer');
+const readPkgUp = require('read-pkg-up');
+const version = require('./version');
+
+module.exports = options => {
+	const pkg = readPkgUp.sync().pkg;
+
+	const prompts = [
+		{
+			type: 'list',
+			name: 'version',
+			message: 'Select semver increment or specify new version',
+			choices: version.SEMVER_INCREMENTS.concat([
+				new inquirer.Separator(),
+				{
+					name: 'Other (specify)',
+					value: null
+				}
+			]),
+			filter(input) {
+				return version.isValidVersionInput(input) ? version.getNewVersion(pkg.version, input) : input;
+			}
+		},
+		{
+			type: 'input',
+			name: 'version',
+			message: 'Version',
+			when(answers) {
+				return !answers.version;
+			},
+			filter(input) {
+				// filter runs before validate that's why we have to check for valid version before we transform them
+				return version.isValidVersionInput(input) ? version.getNewVersion(pkg.version, input) : input;
+			},
+			validate(input) {
+				if (!version.isValidVersionInput(input)) {
+					return 'Please specify a valid semver, e.g. 1.2.3. See http://semver.org/';
+				} else if (!version.isVersionGreater(pkg.version, input)) {
+					return `Version must be greater than ${pkg.version}`;
+				}
+				return true;
+			}
+		},
+		{
+			type: 'list',
+			name: 'tag',
+			message: 'How should this pre-release version be tagged in NPM?',
+			when(answers) {
+				return !pkg.private && version.isPrereleaseVersion(answers.version) && !options.tag;
+			},
+			choices() {
+				return execa.stdout('npm', ['dist-tag', 'ls'])
+					.then(stdout => {
+						const existingPreleaseTags = stdout.split('\n')
+							.map(line => line.split(':')[0].replace(/^\s|\s$/, ''))
+							.filter(line => line)
+							.filter(line => line.toLowerCase() !== 'latest');
+
+						if (!existingPreleaseTags.length) {
+							existingPreleaseTags.push('next');
+						}
+
+						return existingPreleaseTags
+							.concat([
+								new inquirer.Separator(),
+								{
+									name: 'Other (specify)',
+									value: null
+								}
+							]);
+					});
+			}
+		},
+		{
+			type: 'input',
+			name: 'tag',
+			message: 'Tag',
+			when(answers) {
+				return !pkg.private && version.isPrereleaseVersion(answers.version) && !options.tag && !answers.tag;
+			},
+			validate(input) {
+				if (!input.length) {
+					return `Please specify a tag, e.g. next.`;
+				} else if (input.toLowerCase() === 'latest') {
+					return `It's not possible to publish a pre-releases under the latest tag. Please specifiy something else, e.g. next.`;
+				}
+				return true;
+			}
+		},
+		{
+			type: 'confirm',
+			name: 'confirm',
+			message(answers) {
+				const tag = answers.tag || options.tag;
+				const msg = `Will bump from ${pkg.version} to ${answers.version}${tag ? ` and tag this release in NPM as ${tag}` : ''}. Continue?`;
+				return msg;
+			}
+		}
+	];
+
+	return inquirer
+		.prompt(prompts)
+		.then(answers => Object.assign({}, options, answers));
+};

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -1,23 +1,21 @@
 'use strict';
-const semver = require('semver');
 const execa = require('execa');
 const Listr = require('listr');
-
-const VERSIONS = ['major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', 'prerelease'];
-const PRERELEASE_VERSIONS = ['premajor', 'preminor', 'prepatch', 'prerelease'];
+const version = require('./version');
 
 module.exports = (input, pkg, opts) => {
-	const newVersion = VERSIONS.indexOf(input) === -1 ? input : semver.inc(pkg.version, input);
-
+	let newVersion = null;
 	const tasks = [
 		{
 			title: 'Validate version',
 			task: () => {
-				if (VERSIONS.indexOf(input) === -1 && !semver.valid(input)) {
-					throw new Error(`Version should be either ${VERSIONS.join(', ')}, or a valid semver version.`);
+				if (!version.isValidVersionInput(input)) {
+					throw new Error(`Version should be either ${version.SEMVER_INCREMENTS.join(', ')}, or a valid semver version.`);
 				}
 
-				if (semver.gte(pkg.version, newVersion)) {
+				newVersion = version.getNewVersion(pkg.version, input);
+
+				if (!version.isVersionGreater(pkg.version, newVersion)) {
 					throw new Error(`New version \`${newVersion}\` should be higher than current version \`${pkg.version}\``);
 				}
 			}
@@ -25,17 +23,17 @@ module.exports = (input, pkg, opts) => {
 		{
 			title: 'Check for pre-release version',
 			task: () => {
-				if ((PRERELEASE_VERSIONS.indexOf(input) !== -1 || semver.prerelease(input)) && !opts.tag) {
+				if (!pkg.private && version.isPrereleaseVersion(newVersion) && !opts.tag) {
 					throw new Error('You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag');
 				}
 			}
 		},
 		{
 			title: 'Check npm version',
-			skip: () => semver.lt(process.version, '6.0.0'),
+			skip: () => version.isVersionLower(process.version, '6.0.0'),
 			task: () => execa.stdout('npm', ['version', '--json']).then(json => {
 				const versions = JSON.parse(json);
-				if (!semver.satisfies(versions.npm, '>=2.15.8 <3.0.0 || >=3.10.1')) {
+				if (!version.satisfies(versions.npm, '>=2.15.8 <3.0.0 || >=3.10.1')) {
 					throw new Error(`npm@${versions.npm} has known issues publishing when running Node.js 6. Please upgrade npm or downgrade Node and publish again. https://github.com/npm/npm/issues/5082`);
 				}
 			})

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -30,7 +30,7 @@ module.exports = (input, pkg, opts) => {
 		},
 		{
 			title: 'Check npm version',
-			skip: () => version.isVersionLower(process.version, '6.0.0'),
+			skip: () => version.isVersionLower('6.0.0', process.version),
 			task: () => execa.stdout('npm', ['version', '--json']).then(json => {
 				const versions = JSON.parse(json);
 				if (!version.satisfies(versions.npm, '>=2.15.8 <3.0.0 || >=3.10.1')) {

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -52,27 +52,25 @@ module.exports = options => {
 			name: 'tag',
 			message: 'How should this pre-release version be tagged in npm?',
 			when: answers => !pkg.private && version.isPrereleaseVersion(answers.version) && !options.tag,
-			choices: () => {
-				return execa.stdout('npm', ['dist-tag', 'ls'])
-					.then(stdout => {
-						const existingPreleaseTags = stdout.split('\n')
-							.map(line => line.split(':')[0].replace(/^\s|\s$/, ''))
-							.filter(line => line.toLowerCase() !== 'latest');
+			choices: () => execa.stdout('npm', ['dist-tag', 'ls'])
+				.then(stdout => {
+					const existingPrereleaseTags = stdout.split('\n')
+						.map(line => line.split(':')[0].replace(/^\s|\s$/, ''))
+						.filter(line => line.toLowerCase() !== 'latest');
 
-						if (!existingPreleaseTags.length) {
-							existingPreleaseTags.push('next');
-						}
+					if (existingPrereleaseTags.length === 0) {
+						existingPrereleaseTags.push('next');
+					}
 
-						return existingPreleaseTags
-							.concat([
-								new inquirer.Separator(),
-								{
-									name: 'Other (specify)',
-									value: null
-								}
-							]);
-					});
-			}
+					return existingPrereleaseTags
+						.concat([
+							new inquirer.Separator(),
+							{
+								name: 'Other (specify)',
+								value: null
+							}
+						]);
+				})
 		},
 		{
 			type: 'input',
@@ -93,8 +91,9 @@ module.exports = options => {
 			name: 'confirm',
 			message: answers => {
 				const tag = answers.tag || options.tag;
-				const msg = `Will bump from ${oldVersion} to ${answers.version}${tag ? ` and tag this release in npm as ${tag}` : ''}. Continue?`;
-				return msg;
+				const tagPart = tag ? ` and tag this release in npm as ${tag}` : '';
+
+				return `Will bump from ${oldVersion} to ${answers.version}${tagPart}. Continue?`;
 			}
 		}
 	];

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -2,24 +2,35 @@
 const execa = require('execa');
 const inquirer = require('inquirer');
 const readPkgUp = require('read-pkg-up');
+const chalk = require('chalk');
 const version = require('./version');
 
 module.exports = options => {
 	const pkg = readPkgUp.sync().pkg;
+	const oldVersion = pkg.version;
+
+	console.log('\n');
+	console.log(`Releasing a new version of ${chalk.bold(pkg.name)} ${chalk.gray.dim(`(current version: ${oldVersion})`)}`);
+	console.log('\n');
 
 	const prompts = [
 		{
 			type: 'list',
 			name: 'version',
 			message: 'Select semver increment or specify new version',
-			choices: version.SEMVER_INCREMENTS.concat([
-				new inquirer.Separator(),
-				{
-					name: 'Other (specify)',
-					value: null
-				}
-			]),
-			filter: input => version.isValidVersionInput(input) ? version.getNewVersion(pkg.version, input) : input
+			choices: version.SEMVER_INCREMENTS
+				.map(inc => ({
+					name: `${inc} ${chalk.gray.dim(`(${version.getNewVersion(oldVersion, inc)})`)}`,
+					value: inc
+				}))
+				.concat([
+					new inquirer.Separator(),
+					{
+						name: 'Other (specify)',
+						value: null
+					}
+				]),
+			filter: input => version.isValidVersionInput(input) ? version.getNewVersion(oldVersion, input) : input
 		},
 		{
 			type: 'input',
@@ -30,8 +41,8 @@ module.exports = options => {
 			validate: input => {
 				if (!version.isValidVersionInput(input)) {
 					return 'Please specify a valid semver, e.g. 1.2.3. See http://semver.org';
-				} else if (!version.isVersionGreater(pkg.version, input)) {
-					return `Version must be greater than ${pkg.version}`;
+				} else if (!version.isVersionGreater(oldVersion, input)) {
+					return `Version must be greater than ${oldVersion}`;
 				}
 				return true;
 			}
@@ -82,7 +93,7 @@ module.exports = options => {
 			name: 'confirm',
 			message: answers => {
 				const tag = answers.tag || options.tag;
-				const msg = `Will bump from ${pkg.version} to ${answers.version}${tag ? ` and tag this release in npm as ${tag}` : ''}. Continue?`;
+				const msg = `Will bump from ${oldVersion} to ${answers.version}${tag ? ` and tag this release in npm as ${tag}` : ''}. Continue?`;
 				return msg;
 			}
 		}

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -83,7 +83,7 @@ module.exports = options => {
 				if (input.length === 0) {
 					return 'Please specify a tag, e.g. next.';
 				} else if (input.toLowerCase() === 'latest') {
-					return 'It\'s not possible to publish a pre-releases under the latest tag. Please specifiy something else, e.g. next.';
+					return 'It\'s not possible to publish pre-releases under the latest tag. Please specifiy something else, e.g. next.';
 				}
 				return true;
 			}

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -19,24 +19,17 @@ module.exports = options => {
 					value: null
 				}
 			]),
-			filter(input) {
-				return version.isValidVersionInput(input) ? version.getNewVersion(pkg.version, input) : input;
-			}
+			filter: input => version.isValidVersionInput(input) ? version.getNewVersion(pkg.version, input) : input
 		},
 		{
 			type: 'input',
 			name: 'version',
 			message: 'Version',
-			when(answers) {
-				return !answers.version;
-			},
-			filter(input) {
-				// filter runs before validate that's why we have to check for valid version before we transform them
-				return version.isValidVersionInput(input) ? version.getNewVersion(pkg.version, input) : input;
-			},
-			validate(input) {
+			when: answers => !answers.version,
+			filter: input => version.isValidVersionInput(input) ? version.getNewVersion(pkg.version, input) : input,
+			validate: input => {
 				if (!version.isValidVersionInput(input)) {
-					return 'Please specify a valid semver, e.g. 1.2.3. See http://semver.org/';
+					return 'Please specify a valid semver, e.g. 1.2.3. See http://semver.org';
 				} else if (!version.isVersionGreater(pkg.version, input)) {
 					return `Version must be greater than ${pkg.version}`;
 				}
@@ -46,16 +39,13 @@ module.exports = options => {
 		{
 			type: 'list',
 			name: 'tag',
-			message: 'How should this pre-release version be tagged in NPM?',
-			when(answers) {
-				return !pkg.private && version.isPrereleaseVersion(answers.version) && !options.tag;
-			},
-			choices() {
+			message: 'How should this pre-release version be tagged in npm?',
+			when: answers => !pkg.private && version.isPrereleaseVersion(answers.version) && !options.tag,
+			choices: () => {
 				return execa.stdout('npm', ['dist-tag', 'ls'])
 					.then(stdout => {
 						const existingPreleaseTags = stdout.split('\n')
 							.map(line => line.split(':')[0].replace(/^\s|\s$/, ''))
-							.filter(line => line)
 							.filter(line => line.toLowerCase() !== 'latest');
 
 						if (!existingPreleaseTags.length) {
@@ -77,14 +67,12 @@ module.exports = options => {
 			type: 'input',
 			name: 'tag',
 			message: 'Tag',
-			when(answers) {
-				return !pkg.private && version.isPrereleaseVersion(answers.version) && !options.tag && !answers.tag;
-			},
-			validate(input) {
-				if (!input.length) {
-					return `Please specify a tag, e.g. next.`;
+			when: answers => !pkg.private && version.isPrereleaseVersion(answers.version) && !options.tag && !answers.tag,
+			validate: input => {
+				if (input.length === 0) {
+					return 'Please specify a tag, e.g. next.';
 				} else if (input.toLowerCase() === 'latest') {
-					return `It's not possible to publish a pre-releases under the latest tag. Please specifiy something else, e.g. next.`;
+					return 'It\'s not possible to publish a pre-releases under the latest tag. Please specifiy something else, e.g. next.';
 				}
 				return true;
 			}
@@ -92,9 +80,9 @@ module.exports = options => {
 		{
 			type: 'confirm',
 			name: 'confirm',
-			message(answers) {
+			message: answers => {
 				const tag = answers.tag || options.tag;
-				const msg = `Will bump from ${pkg.version} to ${answers.version}${tag ? ` and tag this release in NPM as ${tag}` : ''}. Continue?`;
+				const msg = `Will bump from ${pkg.version} to ${answers.version}${tag ? ` and tag this release in npm as ${tag}` : ''}. Continue?`;
 				return msg;
 			}
 		}

--- a/lib/version.js
+++ b/lib/version.js
@@ -8,35 +8,29 @@ function isValidVersion(input) {
 	return Boolean(semver.valid(input));
 }
 
-exports.isValidVersionInput = function isValidVersionInput(input) {
-	return exports.SEMVER_INCREMENTS.indexOf(input) !== -1 || isValidVersion(input);
-};
+exports.isValidVersionInput = input => exports.SEMVER_INCREMENTS.indexOf(input) !== -1 || isValidVersion(input);
 
-exports.isPrereleaseVersion = function isPrereleaseVersion(version) {
-	return exports.PRERELEASE_VERSIONS.indexOf(version) !== -1 || Boolean(semver.prerelease(version));
-};
+exports.isPrereleaseVersion = version => exports.PRERELEASE_VERSIONS.indexOf(version) !== -1 || Boolean(semver.prerelease(version));
 
-exports.getNewVersion = function getNewVersion(oldVersion, input) {
+exports.getNewVersion = (oldVersion, input) => {
 	if (!exports.isValidVersionInput(input)) {
 		throw new Error(`Version should be either ${exports.SEMVER_INCREMENTS.join(', ')} or a valid semver version.`);
 	}
 	return exports.SEMVER_INCREMENTS.indexOf(input) === -1 ? input : semver.inc(oldVersion, input);
 };
 
-exports.isVersionGreater = function isGreater(oldVersion, newVersion) {
+exports.isVersionGreater = (oldVersion, newVersion) => {
 	if (!isValidVersion(newVersion)) {
 		throw new Error('Version should be a valid semver version.');
 	}
 	return semver.gt(newVersion, oldVersion);
 };
 
-exports.isVersionLower = function isVersionLower(oldVersion, newVersion) {
+exports.isVersionLower = (oldVersion, newVersion) => {
 	if (!isValidVersion(newVersion)) {
 		throw new Error('Version should be a valid semver version.');
 	}
 	return semver.lt(newVersion, oldVersion);
 };
 
-exports.satisfies = function satisfies(version, range) {
-	return semver.satisfies(version, range);
-};
+exports.satisfies = (version, range) => semver.satisfies(version, range);

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,0 +1,42 @@
+'use strict';
+const semver = require('semver');
+
+exports.SEMVER_INCREMENTS = ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease'];
+exports.PRERELEASE_VERSIONS = ['prepatch', 'preminor', 'premajor', 'prerelease'];
+
+function isValidVersion(input) {
+	return Boolean(semver.valid(input));
+}
+
+exports.isValidVersionInput = function isValidVersionInput(input) {
+	return exports.SEMVER_INCREMENTS.indexOf(input) !== -1 || isValidVersion(input);
+};
+
+exports.isPrereleaseVersion = function isPrereleaseVersion(version) {
+	return exports.PRERELEASE_VERSIONS.indexOf(version) !== -1 || Boolean(semver.prerelease(version));
+};
+
+exports.getNewVersion = function getNewVersion(oldVersion, input) {
+	if (!exports.isValidVersionInput(input)) {
+		throw new Error(`Version should be either ${exports.SEMVER_INCREMENTS.join(', ')} or a valid semver version.`);
+	}
+	return exports.SEMVER_INCREMENTS.indexOf(input) === -1 ? input : semver.inc(oldVersion, input);
+};
+
+exports.isVersionGreater = function isGreater(oldVersion, newVersion) {
+	if (!isValidVersion(newVersion)) {
+		throw new Error('Version should be a valid semver version.');
+	}
+	return semver.gt(newVersion, oldVersion);
+};
+
+exports.isVersionLower = function isVersionLower(oldVersion, newVersion) {
+	if (!isValidVersion(newVersion)) {
+		throw new Error('Version should be a valid semver version.');
+	}
+	return semver.lt(newVersion, oldVersion);
+};
+
+exports.satisfies = function satisfies(version, range) {
+	return semver.satisfies(version, range);
+};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "any-observable": "^0.2.0",
     "del": "^2.2.0",
     "execa": "^0.4.0",
+    "inquirer": "^1.2.1",
     "listr": "^0.6.1",
     "meow": "^3.7.0",
     "read-pkg-up": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "dependencies": {
     "any-observable": "^0.2.0",
+    "chalk": "^1.1.3",
     "del": "^2.2.0",
     "execa": "^0.4.0",
     "inquirer": "^1.2.1",

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ $ np --help
     --tag           Publish under a given dist-tag
 
   Examples
+    $ np
     $ np patch
     $ np 1.0.2
     $ np 1.0.2-beta.3 --tag=beta

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import m from './';
 
 test('version is invalid', t => {
-	const message = 'Version should be either major, minor, patch, premajor, preminor, prepatch, prerelease, or a valid semver version.';
+	const message = 'Version should be either patch, minor, major, prepatch, preminor, premajor, prerelease, or a valid semver version.';
 	t.throws(m('foo'), message);
 	t.throws(m('4.x.3'), message);
 });

--- a/test/version.js
+++ b/test/version.js
@@ -95,11 +95,13 @@ test('version.isVersionLower', t => {
 	t.true(version.isVersionLower('1.0.0', '0.1.0'));
 	t.true(version.isVersionLower('1.0.0', '1.0.0-0'));
 	t.true(version.isVersionLower('1.0.0', '1.0.0-beta'));
+	t.true(version.isVersionLower('6.0.0', '4.4.3'));
 
 	t.false(version.isVersionLower('1.0.0', '1.0.0'));
 	t.false(version.isVersionLower('1.0.0', '1.0.1'));
 	t.false(version.isVersionLower('1.0.0', '1.1.0'));
 	t.false(version.isVersionLower('1.0.0', '2.0.0'));
+	t.false(version.isVersionLower('6.0.0', '6.7.0'));
 
 	t.false(version.isVersionLower('1.0.0', '2.0.0-0'));
 	t.false(version.isVersionLower('1.0.0', '2.0.0-beta'));

--- a/test/version.js
+++ b/test/version.js
@@ -1,114 +1,114 @@
 import test from 'ava';
-import {SEMVER_INCREMENTS, PRERELEASE_VERSIONS, isValidVersionInput, isPrereleaseVersion, getNewVersion, isVersionGreater, isVersionLower, satisfies} from '../lib/version';
+import version from '../lib/version';
 
-test('SEMVER_INCREMENTS', t => {
-	t.deepEqual(SEMVER_INCREMENTS, ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease']);
+test('version.SEMVER_INCREMENTS', t => {
+	t.deepEqual(version.SEMVER_INCREMENTS, ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease']);
 });
 
-test('PRERELEASE_VERSIONS', t => {
-	t.deepEqual(PRERELEASE_VERSIONS, ['prepatch', 'preminor', 'premajor', 'prerelease']);
+test('version.PRERELEASE_VERSIONS', t => {
+	t.deepEqual(version.PRERELEASE_VERSIONS, ['prepatch', 'preminor', 'premajor', 'prerelease']);
 });
 
-test('isValidVersionInput', t => {
-	t.false(isValidVersionInput(null));
-	t.false(isValidVersionInput('foo'));
-	t.false(isValidVersionInput('1.0.0.0'));
+test('version.isValidVersionInput', t => {
+	t.false(version.isValidVersionInput(null));
+	t.false(version.isValidVersionInput('foo'));
+	t.false(version.isValidVersionInput('1.0.0.0'));
 
-	t.true(isValidVersionInput('patch'));
-	t.true(isValidVersionInput('minor'));
-	t.true(isValidVersionInput('major'));
-	t.true(isValidVersionInput('prepatch'));
-	t.true(isValidVersionInput('preminor'));
-	t.true(isValidVersionInput('premajor'));
-	t.true(isValidVersionInput('prerelease'));
-	t.true(isValidVersionInput('1.0.0'));
-	t.true(isValidVersionInput('1.1.0'));
-	t.true(isValidVersionInput('1.0.1'));
-	t.true(isValidVersionInput('1.0.0-beta'));
-	t.true(isValidVersionInput('2.0.0-rc.2'));
+	t.true(version.isValidVersionInput('patch'));
+	t.true(version.isValidVersionInput('minor'));
+	t.true(version.isValidVersionInput('major'));
+	t.true(version.isValidVersionInput('prepatch'));
+	t.true(version.isValidVersionInput('preminor'));
+	t.true(version.isValidVersionInput('premajor'));
+	t.true(version.isValidVersionInput('prerelease'));
+	t.true(version.isValidVersionInput('1.0.0'));
+	t.true(version.isValidVersionInput('1.1.0'));
+	t.true(version.isValidVersionInput('1.0.1'));
+	t.true(version.isValidVersionInput('1.0.0-beta'));
+	t.true(version.isValidVersionInput('2.0.0-rc.2'));
 });
 
-test('isPrereleaseVersion', t => {
-	t.false(isPrereleaseVersion('patch'));
-	t.false(isPrereleaseVersion('minor'));
-	t.false(isPrereleaseVersion('major'));
-	t.false(isPrereleaseVersion('1.0.0'));
-	t.false(isPrereleaseVersion('1.1.0'));
-	t.false(isPrereleaseVersion('1.0.1'));
+test('version.isPrereleaseVersion', t => {
+	t.false(version.isPrereleaseVersion('patch'));
+	t.false(version.isPrereleaseVersion('minor'));
+	t.false(version.isPrereleaseVersion('major'));
+	t.false(version.isPrereleaseVersion('1.0.0'));
+	t.false(version.isPrereleaseVersion('1.1.0'));
+	t.false(version.isPrereleaseVersion('1.0.1'));
 
-	t.true(isPrereleaseVersion('prepatch'));
-	t.true(isPrereleaseVersion('preminor'));
-	t.true(isPrereleaseVersion('premajor'));
-	t.true(isPrereleaseVersion('prerelease'));
-	t.true(isPrereleaseVersion('1.0.0-beta'));
-	t.true(isPrereleaseVersion('2.0.0-rc.2'));
+	t.true(version.isPrereleaseVersion('prepatch'));
+	t.true(version.isPrereleaseVersion('preminor'));
+	t.true(version.isPrereleaseVersion('premajor'));
+	t.true(version.isPrereleaseVersion('prerelease'));
+	t.true(version.isPrereleaseVersion('1.0.0-beta'));
+	t.true(version.isPrereleaseVersion('2.0.0-rc.2'));
 });
 
-test('getNewVersion', t => {
+test('version.getNewVersion', t => {
 	const message = 'Version should be either patch, minor, major, prepatch, preminor, premajor, prerelease or a valid semver version.';
 
-	t.throws(() => getNewVersion('1.0.0', 'patchxxx'), message);
-	t.throws(() => getNewVersion('1.0.0', '1.0.0.0'), message);
+	t.throws(() => version.getNewVersion('1.0.0', 'patchxxx'), message);
+	t.throws(() => version.getNewVersion('1.0.0', '1.0.0.0'), message);
 
-	t.is(getNewVersion('1.0.0', 'patch'), '1.0.1');
-	t.is(getNewVersion('1.0.0', 'minor'), '1.1.0');
-	t.is(getNewVersion('1.0.0', 'major'), '2.0.0');
+	t.is(version.getNewVersion('1.0.0', 'patch'), '1.0.1');
+	t.is(version.getNewVersion('1.0.0', 'minor'), '1.1.0');
+	t.is(version.getNewVersion('1.0.0', 'major'), '2.0.0');
 
-	t.is(getNewVersion('1.0.0-beta', 'major'), '1.0.0');
-	t.is(getNewVersion('1.0.0', 'prepatch'), '1.0.1-0');
-	t.is(getNewVersion('1.0.1-0', 'prepatch'), '1.0.2-0');
+	t.is(version.getNewVersion('1.0.0-beta', 'major'), '1.0.0');
+	t.is(version.getNewVersion('1.0.0', 'prepatch'), '1.0.1-0');
+	t.is(version.getNewVersion('1.0.1-0', 'prepatch'), '1.0.2-0');
 
-	t.is(getNewVersion('1.0.0-0', 'prerelease'), '1.0.0-1');
-	t.is(getNewVersion('1.0.1-0', 'prerelease'), '1.0.1-1');
+	t.is(version.getNewVersion('1.0.0-0', 'prerelease'), '1.0.0-1');
+	t.is(version.getNewVersion('1.0.1-0', 'prerelease'), '1.0.1-1');
 });
 
-test('isVersionGreater', t => {
+test('version.isVersionGreater', t => {
 	const message = 'Version should be a valid semver version.';
 
-	t.throws(() => isVersionGreater('1.0.0', 'patch'), message);
-	t.throws(() => isVersionGreater('1.0.0', 'patchxxx'), message);
-	t.throws(() => isVersionGreater('1.0.0', '1.0.0.0'), message);
+	t.throws(() => version.isVersionGreater('1.0.0', 'patch'), message);
+	t.throws(() => version.isVersionGreater('1.0.0', 'patchxxx'), message);
+	t.throws(() => version.isVersionGreater('1.0.0', '1.0.0.0'), message);
 
-	t.false(isVersionGreater('1.0.0', '0.0.1'));
-	t.false(isVersionGreater('1.0.0', '0.1.0'));
-	t.false(isVersionGreater('1.0.0', '1.0.0'));
+	t.false(version.isVersionGreater('1.0.0', '0.0.1'));
+	t.false(version.isVersionGreater('1.0.0', '0.1.0'));
+	t.false(version.isVersionGreater('1.0.0', '1.0.0'));
 
-	t.false(isVersionGreater('1.0.0', '1.0.0-0'));
-	t.false(isVersionGreater('1.0.0', '1.0.0-beta'));
+	t.false(version.isVersionGreater('1.0.0', '1.0.0-0'));
+	t.false(version.isVersionGreater('1.0.0', '1.0.0-beta'));
 
-	t.true(isVersionGreater('1.0.0', '1.0.1'));
-	t.true(isVersionGreater('1.0.0', '1.1.0'));
-	t.true(isVersionGreater('1.0.0', '2.0.0'));
+	t.true(version.isVersionGreater('1.0.0', '1.0.1'));
+	t.true(version.isVersionGreater('1.0.0', '1.1.0'));
+	t.true(version.isVersionGreater('1.0.0', '2.0.0'));
 
-	t.true(isVersionGreater('1.0.0', '2.0.0-0'));
-	t.true(isVersionGreater('1.0.0', '2.0.0-beta'));
+	t.true(version.isVersionGreater('1.0.0', '2.0.0-0'));
+	t.true(version.isVersionGreater('1.0.0', '2.0.0-beta'));
 });
 
-test('isVersionLower', t => {
+test('version.isVersionLower', t => {
 	const message = 'Version should be a valid semver version.';
 
-	t.throws(() => isVersionLower('1.0.0', 'patch'), message);
-	t.throws(() => isVersionLower('1.0.0', 'patchxxx'), message);
-	t.throws(() => isVersionLower('1.0.0', '1.0.0.0'), message);
+	t.throws(() => version.isVersionLower('1.0.0', 'patch'), message);
+	t.throws(() => version.isVersionLower('1.0.0', 'patchxxx'), message);
+	t.throws(() => version.isVersionLower('1.0.0', '1.0.0.0'), message);
 
-	t.true(isVersionLower('1.0.0', '0.0.1'));
-	t.true(isVersionLower('1.0.0', '0.1.0'));
-	t.true(isVersionLower('1.0.0', '1.0.0-0'));
-	t.true(isVersionLower('1.0.0', '1.0.0-beta'));
+	t.true(version.isVersionLower('1.0.0', '0.0.1'));
+	t.true(version.isVersionLower('1.0.0', '0.1.0'));
+	t.true(version.isVersionLower('1.0.0', '1.0.0-0'));
+	t.true(version.isVersionLower('1.0.0', '1.0.0-beta'));
 
-	t.false(isVersionLower('1.0.0', '1.0.0'));
-	t.false(isVersionLower('1.0.0', '1.0.1'));
-	t.false(isVersionLower('1.0.0', '1.1.0'));
-	t.false(isVersionLower('1.0.0', '2.0.0'));
+	t.false(version.isVersionLower('1.0.0', '1.0.0'));
+	t.false(version.isVersionLower('1.0.0', '1.0.1'));
+	t.false(version.isVersionLower('1.0.0', '1.1.0'));
+	t.false(version.isVersionLower('1.0.0', '2.0.0'));
 
-	t.false(isVersionLower('1.0.0', '2.0.0-0'));
-	t.false(isVersionLower('1.0.0', '2.0.0-beta'));
+	t.false(version.isVersionLower('1.0.0', '2.0.0-0'));
+	t.false(version.isVersionLower('1.0.0', '2.0.0-beta'));
 });
 
-test('satisfies', t => {
-	t.true(satisfies('2.15.8', '>=2.15.8 <3.0.0 || >=3.10.1'));
-	t.true(satisfies('2.99.8', '>=2.15.8 <3.0.0 || >=3.10.1'));
-	t.true(satisfies('3.10.1', '>=2.15.8 <3.0.0 || >=3.10.1'));
-	t.false(satisfies('3.0.0', '>=2.15.8 <3.0.0 || >=3.10.1'));
-	t.false(satisfies('3.10.0', '>=2.15.8 <3.0.0 || >=3.10.1'));
+test('version.satisfies', t => {
+	t.true(version.satisfies('2.15.8', '>=2.15.8 <3.0.0 || >=3.10.1'));
+	t.true(version.satisfies('2.99.8', '>=2.15.8 <3.0.0 || >=3.10.1'));
+	t.true(version.satisfies('3.10.1', '>=2.15.8 <3.0.0 || >=3.10.1'));
+	t.false(version.satisfies('3.0.0', '>=2.15.8 <3.0.0 || >=3.10.1'));
+	t.false(version.satisfies('3.10.0', '>=2.15.8 <3.0.0 || >=3.10.1'));
 });

--- a/test/version.js
+++ b/test/version.js
@@ -1,0 +1,114 @@
+import test from 'ava';
+import {SEMVER_INCREMENTS, PRERELEASE_VERSIONS, isValidVersionInput, isPrereleaseVersion, getNewVersion, isVersionGreater, isVersionLower, satisfies} from '../lib/version';
+
+test('SEMVER_INCREMENTS', t => {
+	t.deepEqual(SEMVER_INCREMENTS, ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease']);
+});
+
+test('PRERELEASE_VERSIONS', t => {
+	t.deepEqual(PRERELEASE_VERSIONS, ['prepatch', 'preminor', 'premajor', 'prerelease']);
+});
+
+test('isValidVersionInput', t => {
+	t.false(isValidVersionInput(null));
+	t.false(isValidVersionInput('foo'));
+	t.false(isValidVersionInput('1.0.0.0'));
+
+	t.true(isValidVersionInput('patch'));
+	t.true(isValidVersionInput('minor'));
+	t.true(isValidVersionInput('major'));
+	t.true(isValidVersionInput('prepatch'));
+	t.true(isValidVersionInput('preminor'));
+	t.true(isValidVersionInput('premajor'));
+	t.true(isValidVersionInput('prerelease'));
+	t.true(isValidVersionInput('1.0.0'));
+	t.true(isValidVersionInput('1.1.0'));
+	t.true(isValidVersionInput('1.0.1'));
+	t.true(isValidVersionInput('1.0.0-beta'));
+	t.true(isValidVersionInput('2.0.0-rc.2'));
+});
+
+test('isPrereleaseVersion', t => {
+	t.false(isPrereleaseVersion('patch'));
+	t.false(isPrereleaseVersion('minor'));
+	t.false(isPrereleaseVersion('major'));
+	t.false(isPrereleaseVersion('1.0.0'));
+	t.false(isPrereleaseVersion('1.1.0'));
+	t.false(isPrereleaseVersion('1.0.1'));
+
+	t.true(isPrereleaseVersion('prepatch'));
+	t.true(isPrereleaseVersion('preminor'));
+	t.true(isPrereleaseVersion('premajor'));
+	t.true(isPrereleaseVersion('prerelease'));
+	t.true(isPrereleaseVersion('1.0.0-beta'));
+	t.true(isPrereleaseVersion('2.0.0-rc.2'));
+});
+
+test('getNewVersion', t => {
+	const message = 'Version should be either patch, minor, major, prepatch, preminor, premajor, prerelease or a valid semver version.';
+
+	t.throws(() => getNewVersion('1.0.0', 'patchxxx'), message);
+	t.throws(() => getNewVersion('1.0.0', '1.0.0.0'), message);
+
+	t.is(getNewVersion('1.0.0', 'patch'), '1.0.1');
+	t.is(getNewVersion('1.0.0', 'minor'), '1.1.0');
+	t.is(getNewVersion('1.0.0', 'major'), '2.0.0');
+
+	t.is(getNewVersion('1.0.0-beta', 'major'), '1.0.0');
+	t.is(getNewVersion('1.0.0', 'prepatch'), '1.0.1-0');
+	t.is(getNewVersion('1.0.1-0', 'prepatch'), '1.0.2-0');
+
+	t.is(getNewVersion('1.0.0-0', 'prerelease'), '1.0.0-1');
+	t.is(getNewVersion('1.0.1-0', 'prerelease'), '1.0.1-1');
+});
+
+test('isVersionGreater', t => {
+	const message = 'Version should be a valid semver version.';
+
+	t.throws(() => isVersionGreater('1.0.0', 'patch'), message);
+	t.throws(() => isVersionGreater('1.0.0', 'patchxxx'), message);
+	t.throws(() => isVersionGreater('1.0.0', '1.0.0.0'), message);
+
+	t.false(isVersionGreater('1.0.0', '0.0.1'));
+	t.false(isVersionGreater('1.0.0', '0.1.0'));
+	t.false(isVersionGreater('1.0.0', '1.0.0'));
+
+	t.false(isVersionGreater('1.0.0', '1.0.0-0'));
+	t.false(isVersionGreater('1.0.0', '1.0.0-beta'));
+
+	t.true(isVersionGreater('1.0.0', '1.0.1'));
+	t.true(isVersionGreater('1.0.0', '1.1.0'));
+	t.true(isVersionGreater('1.0.0', '2.0.0'));
+
+	t.true(isVersionGreater('1.0.0', '2.0.0-0'));
+	t.true(isVersionGreater('1.0.0', '2.0.0-beta'));
+});
+
+test('isVersionLower', t => {
+	const message = 'Version should be a valid semver version.';
+
+	t.throws(() => isVersionLower('1.0.0', 'patch'), message);
+	t.throws(() => isVersionLower('1.0.0', 'patchxxx'), message);
+	t.throws(() => isVersionLower('1.0.0', '1.0.0.0'), message);
+
+	t.true(isVersionLower('1.0.0', '0.0.1'));
+	t.true(isVersionLower('1.0.0', '0.1.0'));
+	t.true(isVersionLower('1.0.0', '1.0.0-0'));
+	t.true(isVersionLower('1.0.0', '1.0.0-beta'));
+
+	t.false(isVersionLower('1.0.0', '1.0.0'));
+	t.false(isVersionLower('1.0.0', '1.0.1'));
+	t.false(isVersionLower('1.0.0', '1.1.0'));
+	t.false(isVersionLower('1.0.0', '2.0.0'));
+
+	t.false(isVersionLower('1.0.0', '2.0.0-0'));
+	t.false(isVersionLower('1.0.0', '2.0.0-beta'));
+});
+
+test('satisfies', t => {
+	t.true(satisfies('2.15.8', '>=2.15.8 <3.0.0 || >=3.10.1'));
+	t.true(satisfies('2.99.8', '>=2.15.8 <3.0.0 || >=3.10.1'));
+	t.true(satisfies('3.10.1', '>=2.15.8 <3.0.0 || >=3.10.1'));
+	t.false(satisfies('3.0.0', '>=2.15.8 <3.0.0 || >=3.10.1'));
+	t.false(satisfies('3.10.0', '>=2.15.8 <3.0.0 || >=3.10.1'));
+});


### PR DESCRIPTION
This PR adds a interactive ui when np runs without arguments as suggested in #52.

features:
- choose increment type (e.g. patch) or specify own version (e.g. 0.1.3)
- choose NPM dist-tag for pre-releases (except packages with `"private": true`)
  - user can choose from a list of already existing tags for this package or
  - specifiy a custom tag except latest
- show info about which version you're going from and to.
- user have to confirm the release to prevent accidental publishing of wrong versions
## 

Edit(sindresorhus):

**You can install this PR with: `$ npm i -g 'zinserjan/np#interactive-ui'` and run it with `$ np`.**
## 

<img width="715" alt="screen shot 2016-10-11 at 03 03 21" src="https://cloud.githubusercontent.com/assets/170270/19249354/4e0356ea-8f5f-11e6-89da-4308f13d938e.png">
