### PR TITLE
Use npm view instead of dist-tag

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -51,11 +51,10 @@ module.exports = options => {
 			name: 'tag',
 			message: 'How should this pre-release version be tagged in npm?',
 			when: answers => !pkg.private && version.isPrereleaseVersion(answers.version) && !options.tag,
-			choices: () => execa.stdout('npm', ['dist-tag', 'ls'])
+			choices: () => execa.stdout('npm', ['view', '--json', pkg.name, 'dist-tags'])
 				.then(stdout => {
-					const existingPrereleaseTags = stdout.split('\n')
-						.map(line => line.split(':')[0].replace(/^\s|\s$/, ''))
-						.filter(line => line.toLowerCase() !== 'latest');
+					const existingPrereleaseTags = Object.keys(JSON.parse(stdout))
+						.filter(tag => tag !== 'latest');
 
 					if (existingPrereleaseTags.length === 0) {
 						existingPrereleaseTags.push('next');


### PR DESCRIPTION
[npm dist-tag](https://docs.npmjs.com/cli/dist-tag) is currently [not supported in Nexus](https://issues.sonatype.org/browse/NEXUS-9862).
This commit uses [npm view](https://docs.npmjs.com/cli/view) to retrieve the dist tags so that people using Nexus as a [npm private registry](https://books.sonatype.com/nexus-book/reference/npm.html) can use np to publish pre-release versions of their modules.