### PR TITLE
Surface errors from failed 'version' scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,8 +74,7 @@ module.exports = (input, opts) => {
 
 	tasks.add({
 		title: 'Bumping version',
-		// Specify --force flag to proceed even if the working directory is dirty as np already does a dirty check anyway
-		task: () => exec('npm', ['version', input, '--force'])
+		task: () => exec('npm', ['version', input])
 	});
 
 	if (runPublish) {


### PR DESCRIPTION
The npm scripts `preversion` and `version` could fail for legitimate reasons
(examples include: auto-updating CHANGELOG.md, or performing a sanity check
on that same file). The --force switch will ignore any of these errors and
continue with publishing the new version regardless.

This change surfaces the errors (which were previously silent).

NOTE: since `np` already checks for a dirty working environment, --force is
superfluous at the `npm version` stage.

An example of the new output seen when `version` fails is similar to:

```bash
$ ../np/cli.js --no-cleanup --no-publish

Publish a new version of some-module (1.0.2)

? Select semver increment or specify new version patch (1.0.3)
? Will bump from 1.0.2 to 1.0.3. Continue? Yes
 ✔ Prerequisite check
 ✔ Git
 ✔ Running tests
 ✖ Bumping version
   Pushing tags

✖ Command failed: npm version 1.0.3
No valid CHANGELOG info found after heading "## [1.0.3][] - 2017-01-24"

[... NPM error log here]
```