### PR TITLE
Allow optional forcing of npm version command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,11 +15,12 @@ const cli = meow(`
 	    ${version.SEMVER_INCREMENTS.join(' | ')} | 1.2.3
 
 	Options
-	  --any-branch  Allow publishing from any branch
-	  --no-cleanup  Skips cleanup of node_modules
-	  --yolo        Skips cleanup and testing
-	  --no-publish  Skips publishing
-	  --tag         Publish under a given dist-tag
+	  --any-branch    Allow publishing from any branch
+	  --force-version Ignores errors from npm version
+	  --no-cleanup    Skips cleanup of node_modules
+	  --no-publish    Skips publishing
+	  --tag           Publish under a given dist-tag
+	  --yolo          Skips cleanup and testing
 
 	Examples
 	  $ np

--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ module.exports = (input, opts) => {
 
 	opts = Object.assign({
 		cleanup: true,
-		publish: true
+		publish: true,
+		forceVersion: false
 	}, opts);
 
 	// TODO: remove sometime far in the future
@@ -36,6 +37,7 @@ module.exports = (input, opts) => {
 
 	const runTests = !opts.yolo;
 	const runCleanup = opts.cleanup && !opts.yolo;
+	const forceVersion = opts.yolo || opts.forceVersion;
 	const runPublish = opts.publish;
 	const pkg = util.readPkg();
 
@@ -74,8 +76,7 @@ module.exports = (input, opts) => {
 
 	tasks.add({
 		title: 'Bumping version',
-		// Specify --force flag to proceed even if the working directory is dirty as np already does a dirty check anyway
-		task: () => exec('npm', ['version', input, '--force'])
+		task: () => exec('npm', ['version', input].concat(forceVersion ? ['--force'] : []))
 	});
 
 	if (runPublish) {


### PR DESCRIPTION
Originally in #75, `--force` was added due to build artefacts making `npm version` fail:

> 1. Starting with a clean master, run `np patch`
> 1. `np` does dirty checking and everything is legit, moves on
> 1. As a prerequisite to running the tests we do a build of the module which changes some of the dist files
> 1. When `np` gets to the `npm version` step this step fails because the tree is now dirty

However, the npm scripts `preversion` and `version` could fail for legitimate reasons
(examples include: auto-updating CHANGELOG.md, or performing a sanity check
on that same file). The `--force` switch will ignore any of these errors and
continue with publishing the new version regardless, resulting in a false positive.

This change allows surfacing the errors (which were previously silent) by making `--force` an opt-in option (fail by default so we don't accidentally publish bad versions because we forgot a switch):

```
np --force-version
```

An example of the new output seen when `version` fails (but `--force-version` is not set):

```bash
$ ../np/cli.js --no-cleanup --no-publish

Publish a new version of some-module (1.0.2)

? Select semver increment or specify new version patch (1.0.3)
? Will bump from 1.0.2 to 1.0.3. Continue? Yes
 ✔ Prerequisite check
 ✔ Git
 ✔ Running tests
 ✖ Bumping version
   Pushing tags

✖ Command failed: npm version 1.0.3
No valid CHANGELOG info found after heading "## [1.0.3][] - 2017-01-24"

[... NPM error log here]
```