### PR TITLE
Check yarn.lock integrity - fixes #134

### DIFF
--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -3,14 +3,6 @@ const execa = require('execa');
 const Listr = require('listr');
 const version = require('./version');
 
-const isExecutable = output => {
-	if (process.platform === 'win32') {
-		return !/'(?:.*?)' is not recognized as an internal or external command/.test(output.stderr);
-	}
-
-	return output.code !== 'ENOENT';
-};
-
 module.exports = (input, pkg, opts) => {
 	let newVersion = null;
 
@@ -52,7 +44,7 @@ module.exports = (input, pkg, opts) => {
 			enabled: () => opts.yarn,
 			task: () => execa.stdout('yarn', ['check', '--integrity'])
 				.catch(err => {
-					if (!isExecutable(err)) {
+					if (err.code === 'ENOENT') {
 						throw new Error('Yarn not available, run `npm install -g yarn` to install or use the `--no-yarn` flag');
 					}
 

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -3,6 +3,14 @@ const execa = require('execa');
 const Listr = require('listr');
 const version = require('./version');
 
+const isExecutable = output => {
+	if (process.platform === 'win32') {
+		return !/'(?:.*?)' is not recognized as an internal or external command/.test(output.stderr);
+	}
+
+	return output.code !== 'ENOENT';
+};
+
 module.exports = (input, pkg, opts) => {
 	let newVersion = null;
 
@@ -44,7 +52,7 @@ module.exports = (input, pkg, opts) => {
 			enabled: () => opts.yarn,
 			task: () => execa.stdout('yarn', ['check', '--integrity'])
 				.catch(err => {
-					if (err.code === 'ENOENT') {
+					if (!isExecutable(err)) {
 						throw new Error('Yarn not available, run `npm install -g yarn` to install or use the `--no-yarn` flag');
 					}
 

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -40,6 +40,18 @@ module.exports = (input, pkg, opts) => {
 			})
 		},
 		{
+			title: 'Check yarn.lock integrity',
+			enabled: () => opts.yarn,
+			task: () => execa.stdout('yarn', ['check', '--integrity'])
+				.catch(err => {
+					if (err.code === 'ENOENT') {
+						throw new Error('Yarn not available, run `npm install -g yarn` to install or use the `--no-yarn` flag');
+					}
+
+					throw new Error('`yarn.lock` file is outdated, run `yarn`, commit your changes and try again');
+				})
+		},
+		{
 			title: 'Check git tag existence',
 			task: () => execa('git', ['fetch'])
 				.then(() => execa.stdout('git', ['rev-parse', '--quiet', '--verify', `refs/tags/v${newVersion}`]))

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "any-observable": "^0.2.0",
     "chalk": "^1.1.3",
     "del": "^2.2.0",
-    "execa": "^0.6.0",
+    "execa": "^0.6.3",
     "has-yarn": "^1.0.0",
     "inquirer": "^3.0.6",
     "listr": "^0.11.0",


### PR DESCRIPTION
This PR fixes #134 by using `yarn check --integrity`. This check fails if the `package.json` doesn't match the `yarn.lock` file.

I chose to throw a custom error with a step on how to fix it instead of just throwing the output of that check which looks like

> error Lockfile does not contain pattern: "rxjs@^5.2.0"
> error Integrity hashes don't match, expected "730f87896cc809a098033ac423e0699d2693323371a33
> cc40cd276ac77665687" but got "e5eb319a8d0de9c04a07da3ffd015c0235eb0cd732e17e7f3ecae603fb64a6c0"
> error Found 2 errors.
> yarn check v0.22.0
> info Visit https://yarnpkg.com/en/docs/cli/check for documentation about this command.

// @gillesdemey @rarkins