### PR TITLE
Skip npm check when skipping publishing

### DIFF
--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -31,7 +31,7 @@ module.exports = (input, pkg, opts) => {
 		},
 		{
 			title: 'Check npm version',
-			skip: () => version.isVersionLower('6.0.0', process.version),
+			skip: () => !opts.publish || version.isVersionLower('6.0.0', process.version),
 			task: () => execa.stdout('npm', ['version', '--json']).then(json => {
 				const versions = JSON.parse(json);
 				if (!version.satisfies(versions.npm, '>=2.15.8 <3.0.0 || >=3.10.1')) {


### PR DESCRIPTION
The npm check is only relevant when publishing a package.
When skipping publishing (with the --no-publish CLI option), the npm
check should be skipped otherwise np could fail if one doesn't have a
version of npm that satisfy the check.

I just discovered this bug when using np with
* the CLI option --no-publish
* Node 6
* npm 3.10.0 (which doesn't satisfy the check)