### PR TITLE
Disable dist-tag check when running with `--no-publish` - fixes #140

### DIFF
--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -23,6 +23,7 @@ module.exports = (input, pkg, opts) => {
 		},
 		{
 			title: 'Check for pre-release version',
+			enabled: () => opts.publish,
 			task: () => {
 				if (!pkg.private && version.isPrereleaseVersion(newVersion) && !opts.tag) {
 					throw new Error('You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag');


### PR DESCRIPTION
The dist tag check is not executed when `--no-publish` is used.