### PR TITLE
Fix yarn integrity check error message

### DIFF
--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -49,7 +49,7 @@ module.exports = (input, pkg, opts) => {
 						throw new Error('Yarn not available, run `npm install -g yarn` to install or use the `--no-yarn` flag');
 					}
 
-					throw new Error('`yarn.lock` file is outdated, run `yarn`, commit your changes and try again');
+					throw new Error('Yarn integrity check failed. Run `yarn`, commit your changes (if applicable), and try again');
 				})
 		},
 		{


### PR DESCRIPTION
Closes #144

The yarn integrity check will fail not just because of a `yarn.lock` mismatch, but also if `node_modules` are out of date. This updated error message is more generic to match these possibilities.