### PR TITLE
Swap prerequisite yarn check with frozen lockfile on install

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = (input, opts) => {
 			{
 				title: 'Installing dependencies using Yarn',
 				enabled: () => opts.yarn === true,
-				task: () => exec('yarn', ['install', '--frozen-lockfile']).catch((err) => {
+				task: () => exec('yarn', ['install', '--frozen-lockfile']).catch(err => {
 					if (err.stderr.startsWith('error Your lockfile needs to be updated')) {
 						throw new Error('yarn.lock file is outdated. Run yarn, commit the updated lockfile and try again.');
 					}

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = (input, opts) => {
 			{
 				title: 'Installing dependencies using Yarn',
 				enabled: () => opts.yarn === true,
-				task: () => exec('yarn', ['install'])
+				task: () => exec('yarn', ['install', '--frozen-lockfile'])
 			},
 			{
 				title: 'Installing dependencies using npm',

--- a/index.js
+++ b/index.js
@@ -68,11 +68,11 @@ module.exports = (input, opts) => {
 				title: 'Installing dependencies using Yarn',
 				enabled: () => opts.yarn === true,
 				task: () => exec('yarn', ['install', '--frozen-lockfile']).catch((err) => {
-          if (err.stderr.startsWith('error Your lockfile needs to be updated')) {
-            throw new Error('yarn.lock file is outdated. Run yarn, commit the updated lockfile and try again.');
-          }
-          throw err;
-        })
+					if (err.stderr.startsWith('error Your lockfile needs to be updated')) {
+						throw new Error('yarn.lock file is outdated. Run yarn, commit the updated lockfile and try again.');
+					}
+					throw err;
+				})
 			},
 			{
 				title: 'Installing dependencies using npm',

--- a/index.js
+++ b/index.js
@@ -67,7 +67,12 @@ module.exports = (input, opts) => {
 			{
 				title: 'Installing dependencies using Yarn',
 				enabled: () => opts.yarn === true,
-				task: () => exec('yarn', ['install', '--frozen-lockfile'])
+				task: () => exec('yarn', ['install', '--frozen-lockfile']).catch((err) => {
+          if (err.stderr.startsWith('error Your lockfile needs to be updated')) {
+            throw new Error('yarn.lock file is outdated. Run yarn, commit the updated lockfile and try again.');
+          }
+          throw err;
+        })
 			},
 			{
 				title: 'Installing dependencies using npm',

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -41,18 +41,6 @@ module.exports = (input, pkg, opts) => {
 			})
 		},
 		{
-			title: 'Check yarn.lock integrity',
-			enabled: () => opts.yarn,
-			task: () => execa.stdout('yarn', ['check', '--integrity'])
-				.catch(err => {
-					if (err.code === 'ENOENT') {
-						throw new Error('Yarn not available, run `npm install -g yarn` to install or use the `--no-yarn` flag');
-					}
-
-					throw new Error('`yarn.lock` file is outdated, run `yarn`, commit your changes and try again');
-				})
-		},
-		{
 			title: 'Check git tag existence',
 			task: () => execa('git', ['fetch'])
 				.then(() => execa.stdout('git', ['rev-parse', '--quiet', '--verify', `refs/tags/v${newVersion}`]))


### PR DESCRIPTION
Fixes #144. The `yarn check` command has extra behaviour outside of checking if the lockfile needs to be updated and the message it fails with is a little confusing, which is causing some of the problems discussed in #144. Using `--frozen-lockfile` on install will also guarantee that a mismatch will cause a failure instead of updating the lockfile, but without the extra requirements `check` has.

Here's a sample of the output:
```
? Select semver increment or specify new version patch 	4.2.3
? Will bump from 4.2.2 to 4.2.3. Continue? Yes
 ✔ Prerequisite check
 ✔ Git
 ✔ Cleanup
 ✖ Installing dependencies using Yarn
   → info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this com…
   Running tests
   Bumping version
   Publishing package
   Pushing tags

✖ Command failed: yarn install --frozen-lockfile
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
yarn install v0.21.3
[1/4] Resolving packages...
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

I think the error is a little clearer and it still fixes the original problem `yarn check` was added to solve. The main downside is that this will fail after the cleanup's run, so node_modules will be gone, but tracked files will be in a clean state.

---

Closes #145 