### PR TITLE
Use `yarn version` when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,10 +84,18 @@ module.exports = (input, opts) => {
 		});
 	}
 
-	tasks.add({
-		title: 'Bumping version',
-		task: () => exec('npm', ['version', input])
-	});
+	tasks.add([
+		{
+			title: 'Bumping version using Yarn',
+			enabled: () => opts.yarn === true,
+			task: () => exec('yarn', ['version', input])
+		},
+		{
+			title: 'Bumping version using npm',
+			enabled: () => opts.yarn === false,
+			task: () => exec('npm', ['version', input])
+		}
+	]);
 
 	if (runPublish) {
 		tasks.add({


### PR DESCRIPTION
yarn's version script has slightly different semantics / operation to npm's. In particular, [`npm` will not search the parent tree for `.git` folders](https://github.com/npm/npm/blob/bf3bd1e4347ee2c5de08d23558c4444749178c8b/lib/version.js#L182-L184), however [yarn will](https://github.com/yarnpkg/yarn/blob/e7e2aa7a5252aeb8ca9760b0a2dc6ee5f923f964/src/cli/commands/version.js#L130-L139).

Searching parent tree for `.git` enables having multiple packages contained within their own subfolders of a single repository, for example:

```
.
├── .git
├── README.md
├── some-module
│   ├── package.json
│   ├── index.js
│   └── yarn.lock
└── another-thing
    ├── package.json
    ├── index.js
    └── yarn.lock
```

With this change, it will enable:

```
cd some-module
np
```