### PR TITLE
Add otp option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,7 @@ const cli = meow(`
 	  --no-publish  Skips publishing
 	  --tag         Publish under a given dist-tag
 	  --no-yarn     Don't use Yarn
+	  --otp         Use a one-time password for publishing
 
 	Examples
 	  $ np

--- a/index.js
+++ b/index.js
@@ -110,7 +110,10 @@ module.exports = (input, opts) => {
 					return 'Private package: not publishing to npm.';
 				}
 			},
-			task: () => exec('npm', ['publish'].concat(opts.tag ? ['--tag', opts.tag] : []))
+			task: () => exec('npm', ['publish'].concat(
+				opts.tag ? ['--tag', opts.tag] : [],
+				opts.otp ? ['--otp', opts.otp] : []
+			))
 		});
 	}
 


### PR DESCRIPTION
This is the easiest possible solution for #184. It uses the `--otp` option for `npm publish` which is [documented here](https://github.com/npm/npm/blob/7dc14c81cc8793261f597fd6360e3ebb1699bfee/doc/cli/npm-publish.md).

Ideally, the execution of the publish task would pause if `npm` prompted for a one-time password allowing it to be read from `stdin`, but I couldn't figure out how to get that to work. As a reference, here's how [npm is requesting the otp](https://github.com/npm/npm/blob/7dc14c81cc8793261f597fd6360e3ebb1699bfee/lib/publish.js#L204-L210).

I understand if it'd be worth it to wait for a more robust solution over merging something that might get deprecated soon. But I thought if there was enough requests for this feature that this would be a nice way to allow `np` and two-factor auth to work together.