### PR TITLE
Add --target option for npm publish

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,7 @@ const cli = meow(`
 	  --no-publish  Skips publishing
 	  --tag         Publish under a given dist-tag
 	  --no-yarn     Don't use Yarn
+	  --target      Path to tarball or folder to publish
 
 	Examples
 	  $ np

--- a/index.js
+++ b/index.js
@@ -103,6 +103,16 @@ module.exports = (input, opts) => {
 	]);
 
 	if (runPublish) {
+		const publishArgs = [];
+
+		if (opts.target) {
+			publishArgs.push(opts.target);
+		}
+
+		if (opts.tag) {
+			publishArgs.push('--tag', opts.tag);
+		}
+
 		tasks.add({
 			title: 'Publishing package',
 			skip: () => {
@@ -110,7 +120,7 @@ module.exports = (input, opts) => {
 					return 'Private package: not publishing to npm.';
 				}
 			},
-			task: () => exec('npm', ['publish'].concat(opts.tag ? ['--tag', opts.tag] : []))
+			task: () => exec('npm', ['publish'].concat(publishArgs))
 		});
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ $ np --help
     --no-publish  Skips publishing
     --tag         Publish under a given dist-tag
     --no-yarn     Don't use Yarn
+    --target      Path to tarball or folder to publish
 
   Examples
     $ np


### PR DESCRIPTION
`npm publish` can publish a tarball or folder by accepting a 1st argument. This PR adds a new `--target` option to customize this. https://docs.npmjs.com/cli/publish#description

This is handy for packages that want to publish from the built ./lib folder instead of the root.