### PR TITLE
Use `yarn publish` for Yarn

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,28 +103,38 @@ module.exports = (input, opts) => {
 	]);
 
 	if (runPublish) {
-		tasks.add({
-			title: 'Publishing package using Yarn',
-			enabled: () => opts.yarn === true,
-			skip: () => {
-				if (pkg.private) {
-					return 'Private package: not publishing to Yarn.';
+		tasks.add(
+			{
+				title: 'Publishing package using Yarn',
+				enabled: () => opts.yarn === true,
+				skip: () => {
+					if (pkg.private) {
+						return 'Private package: not publishing to Yarn.';
+					}
+				},
+				task: () => {
+					const args = ['publish', '--new-version', input];
+
+					if (opts.tag) {
+						args.push('--tag', opts.tag);
+					}
+
+					return exec('yarn', args).catch(err => {
+						throw new Error(err);
+					});
 				}
 			},
-			task: () => exec('yarn', ['publish', '--new-version', input]).catch(err => {
-				throw new Error(err);
-			})
-		},
-		{
-			title: 'Publishing package using npm',
-			enabled: () => opts.yarn === false,
-			skip: () => {
-				if (pkg.private) {
-					return 'Private package: not publishing to npm.';
-				}
-			},
-			task: (ctx, task) => publish(task, opts.tag)
-		});
+			{
+				title: 'Publishing package using npm',
+				enabled: () => opts.yarn === false,
+				skip: () => {
+					if (pkg.private) {
+						return 'Private package: not publishing to npm.';
+					}
+				},
+				task: (ctx, task) => publish(task, opts.tag)
+			}
+		);
 	}
 
 	tasks.add({

--- a/index.js
+++ b/index.js
@@ -104,7 +104,20 @@ module.exports = (input, opts) => {
 
 	if (runPublish) {
 		tasks.add({
-			title: 'Publishing package',
+			title: 'Publishing package using Yarn',
+			enabled: () => opts.yarn === true,
+			skip: () => {
+				if (pkg.private) {
+					return 'Private package: not publishing to Yarn.';
+				}
+			},
+			task: () => exec('yarn', ['publish', '--new-version', input]).catch(err => {
+				throw new Error(err);
+			})
+		},
+		{
+			title: 'Publishing package using npm',
+			enabled: () => opts.yarn === false,
 			skip: () => {
 				if (pkg.private) {
 					return 'Private package: not publishing to npm.';

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = (input, opts) => {
 	]);
 
 	if (runPublish) {
-		tasks.add(
+		tasks.add([
 			{
 				title: 'Publishing package using Yarn',
 				enabled: () => opts.yarn === true,
@@ -134,7 +134,7 @@ module.exports = (input, opts) => {
 				},
 				task: (ctx, task) => publish(task, opts.tag)
 			}
-		);
+		]);
 	}
 
 	tasks.add({


### PR DESCRIPTION
refs #216, #203, etc

I've genuinely been pulling my hair out with np for the last 3 days. I've done my absolute best to try to contribute a fix because I love this tool, but I'm utterly lost 😭 

I've tried to fix the npm publish, but I just don't understand how exec/execa/observable are all related.

Instead I've tried to add yarn publish support, but although the publish happens, the flow of control never returns back to listr it seems, so it sits and hangs forever, and never gets as far as pushing the tags. I am at a loss for how to debug.

This PR includes that attempt.

Can someone who understands listr, execa, etc etc take a look and see if they can find an easy fix?

I'd also love to know as well:
 - what does the streamToObservable wrapper in index.js & observableFromPublish code in `publish.js` achieve? 
- how come in publish.js `execa` is used directly, although everywhere else it is `execa.stdout`

If someone can point me at some related reading that would make this make sense I'd be grateful!

