### PR TITLE
Skip "Ping npm registry" task when using `--no-publish`

### DIFF
--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -12,7 +12,7 @@ module.exports = (input, pkg, opts) => {
 	const tasks = [
 		{
 			title: 'Ping npm registry',
-			skip: () => pkg.private || isExternalRegistry,
+			skip: () => pkg.private || isExternalRegistry || !opts.publish,
 			task: () => pTimeout(execa.stdout('npm', ['ping'])
 				.catch(() => {
 					throw new Error('Connection to npm registry failed');

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -20,7 +20,7 @@ module.exports = (input, pkg, opts) => {
 		},
 		{
 			title: 'Verify user is authenticated',
-			skip: () => process.env.NODE_ENV === 'test' || pkg.private || isExternalRegistry,
+			skip: () => process.env.NODE_ENV === 'test' || pkg.private || isExternalRegistry || !opts.publish,
 			task: () => execa.stdout('npm', ['whoami'])
 				.catch(err => {
 					throw new Error(/ENEEDAUTH/.test(err.stderr) ?
@@ -72,7 +72,7 @@ module.exports = (input, pkg, opts) => {
 		},
 		{
 			title: 'Check npm version',
-			skip: () => version.isVersionLower('6.0.0', process.version),
+			skip: () => version.isVersionLower('6.0.0', process.version) || !opts.publish,
 			task: () => execa.stdout('npm', ['version', '--json']).then(json => {
 				const versions = JSON.parse(json);
 				if (!version.satisfies(versions.npm, '>=2.15.8 <3.0.0 || >=3.10.1')) {


### PR DESCRIPTION
Skip the task 'Ping npm registry' when the option `--no-publish` is
present on the command line, as this task is only useful when publishing
a package.

I tried to run `np --no-publish` with a custom npm registry ([Nexus](https://help.sonatype.com/display/NXRM3/Node+Packaged+Modules+and+npm+Registries)) set in `~/.npmrc` and this fails without this patch as it tries to ping the npm registry, which is unfortunately [not supported on Nexus](https://issues.sonatype.org/browse/NEXUS-13434).