### PR TITLE
Don't run version script twice when publishing with Yarn

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,11 +91,6 @@ module.exports = (input, opts) => {
 
 	tasks.add([
 		{
-			title: 'Bumping version using Yarn',
-			enabled: () => opts.yarn === true,
-			task: () => exec('yarn', ['version', '--new-version', input])
-		},
-		{
 			title: 'Bumping version using npm',
 			enabled: () => opts.yarn === false,
 			task: () => exec('npm', ['version', input])


### PR DESCRIPTION
During publish the `version` script was being run twice, which breaks scripts that do things like bump changelogs. `yarn publish` automatically does the same thing as `yarn version` so the first step can be skipped.