### PR TITLE
Show list of commits before prompt - fixes #238

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -33,7 +33,7 @@ function printCommitLog(repositoryUrl) {
 		.then(result => {
 			const history = result.split('\n')
 				.map(commit => {
-					const commitParts = commit.match(/^(.+)\s([a-f0-9]{7})$/);
+					const commitParts = commit.match(/^(.+)\s([a-f\d]{7})$/);
 
 					const commitMessage = util.linkifyIssues(repositoryUrl, commitParts[1]);
 					const commitId = util.linkifyCommit(repositoryUrl, commitParts[2]);

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -1,7 +1,6 @@
 'use strict';
 const execa = require('execa');
 const inquirer = require('inquirer');
-const pTap = require('p-tap');
 const chalk = require('chalk');
 const githubUrlFromGit = require('github-url-from-git');
 const util = require('./util');
@@ -26,6 +25,25 @@ function prettyVersionDiff(oldVersion, inc) {
 		}
 	}
 	return output.join(chalk.reset.dim('.'));
+}
+
+function printCommitLog(repositoryUrl) {
+	return execa.stdout('git', ['rev-list', `--tags`, '--max-count=1'])
+		.then(latestHash => execa.stdout('git', ['log', '--format=%s %h', `${latestHash}..HEAD`]))
+		.then(result => {
+			const history = result.split('\n')
+				.map(commit => {
+					const commitParts = commit.match(/^(.+)\s([a-f0-9]{7})$/);
+
+					const commitMessage = util.linkifyIssues(repositoryUrl, commitParts[1]);
+					const commitId = util.linkifyCommit(repositoryUrl, commitParts[2]);
+
+					return `- ${commitMessage}  ${commitId}`;
+				})
+				.join('\n');
+
+			console.log(`${chalk.bold('Commits:')}\n${history}\n`);
+		});
 }
 
 module.exports = options => {
@@ -113,40 +131,20 @@ module.exports = options => {
 
 				return true;
 			}
+		},
+		{
+			type: 'confirm',
+			name: 'confirm',
+			message: answers => {
+				const tag = answers.tag || options.tag;
+				const tagPart = tag ? ` and tag this release in npm as ${tag}` : '';
+
+				return `Will bump from ${chalk.cyan(oldVersion)} to ${chalk.cyan(answers.version + tagPart)}. Continue?`;
+			}
 		}
 	];
 
-	return inquirer.prompt(prompts)
-		.then(answers => Object.assign({}, options, answers))
-		.then(pTap(() => execa.stdout('git', ['rev-list', `--tags`, '--max-count=1'])
-			.then(latestHash => execa.stdout('git', ['log', '--format=%s %h', `${latestHash}..HEAD`]))
-			.then(result => {
-				const history = result.split('\n')
-					.map(commit => {
-						const commitParts = commit.match(/^(.+)\s([a-f0-9]{7})$/);
-
-						const commitMessage = util.linkifyIssues(repositoryUrl, commitParts[1]);
-						const commitId = util.linkifyCommit(repositoryUrl, commitParts[2]);
-
-						return `- ${commitMessage}  ${commitId}`;
-					})
-					.join('\n');
-
-				console.log(`\n${chalk.bold('Commits:')}\n${history}\n`);
-			})))
-		.then(answers => {
-			const confirmPrompt = {
-				type: 'confirm',
-				name: 'confirm',
-				message: () => {
-					const tag = answers.tag || options.tag;
-					const tagPart = tag ? ` and tag this release in npm as ${tag}` : '';
-
-					return `Will bump from ${chalk.cyan(oldVersion)} to ${chalk.cyan(answers.version + tagPart)}. Continue?`;
-				}
-			};
-
-			return inquirer.prompt(confirmPrompt)
-				.then(answer => Object.assign({}, answers, answer));
-		});
+	return printCommitLog(repositoryUrl)
+		.then(() => inquirer.prompt(prompts))
+		.then(answers => Object.assign({}, options, answers));
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "listr-input": "^0.1.1",
     "log-symbols": "^2.1.0",
     "meow": "^4.0.0",
-    "p-tap": "^1.0.0",
     "p-timeout": "^2.0.1",
     "read-pkg-up": "^3.0.0",
     "rxjs": "5.4.3",


### PR DESCRIPTION
This PR resolves #238 and cleans up the `ui.js` file quite a bit because the inquirer prompt messages can now be merged. :tada: