### PR TITLE
Handle undefined repository URL in the linkify commits feature

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -31,7 +31,7 @@ function prettyVersionDiff(oldVersion, inc) {
 module.exports = options => {
 	const pkg = util.readPkg();
 	const oldVersion = pkg.version;
-	const repositoryUrl = githubUrlFromGit(pkg.repository.url);
+	const repositoryUrl = pkg.repository && githubUrlFromGit(pkg.repository.url);
 
 	console.log(`\nPublish a new version of ${chalk.bold.magenta(pkg.name)} ${chalk.dim(`(current: ${oldVersion})`)}\n`);
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -15,7 +15,7 @@ exports.readPkg = () => {
 };
 
 exports.linkifyIssues = (url, message) => {
-	if (!supportsHyperlinks.stdout) {
+	if (!url || !supportsHyperlinks.stdout) {
 		return message;
 	}
 
@@ -31,7 +31,7 @@ exports.linkifyIssues = (url, message) => {
 };
 
 exports.linkifyCommit = (url, commit) => {
-	if (!supportsHyperlinks.stdout) {
+	if (!url || !supportsHyperlinks.stdout) {
 		return commit;
 	}
 


### PR DESCRIPTION
Trying the new version of np on a project that doesn't define the repository entry in `package.json` results in this error

> Cannot read property 'url' of undefined

This is related to commit 263b0c3c92365525c2b1887b069a6ca9d0c508ef (linkify commits) which assumes that the repository entry is always present in `package.json`, which is not always the case.

This simply check that `pkg.repository` is defined before using `pkg.repository.url`.