### PR TITLE
Switch between npm & yarn for tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,10 +83,18 @@ module.exports = (input, opts) => {
 	}
 
 	if (runTests) {
-		tasks.add({
-			title: 'Running tests',
-			task: () => exec('npm', ['test'])
-		});
+		tasks.add([
+			{
+				title: 'Running tests using npm',
+				enabled: () => opts.yarn === false,
+				task: () => exec('npm', ['test'])
+			},
+			{
+				title: 'Running tests using Yarn',
+				enabled: () => opts.yarn === true,
+				task: () => exec('yarn', ['test'])
+			}
+		]);
 	}
 
 	tasks.add([


### PR DESCRIPTION
I noticed that in yarn mode, np still runs `npm test`.
As the way scripts are run differs slightly between yarn & npm, this is important in some cases.

This is the only remaining place where np uses npm in yarn mode.

- Removing final usage of npm whilst in yarn mode