### PR TITLE
Add `--no-git-tag-version` flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,12 +16,13 @@ const cli = meow(`
 	    ${version.SEMVER_INCREMENTS.join(' | ')} | 1.2.3
 
 	Options
-	  --any-branch  Allow publishing from any branch
-	  --no-cleanup  Skips cleanup of node_modules
-	  --yolo        Skips cleanup and testing
-	  --no-publish  Skips publishing
-	  --tag         Publish under a given dist-tag
-	  --no-yarn     Don't use Yarn
+	  --any-branch          Allow publishing from any branch
+	  --no-cleanup          Skips cleanup of node_modules
+	  --yolo                Skips cleanup and testing
+	  --no-publish          Skips publishing
+	  --no-git-tag-version  Skips commit of a version tag
+	  --tag                 Publish under a given dist-tag
+	  --no-yarn             Don't use Yarn
 
 	Examples
 	  $ np
@@ -46,6 +47,10 @@ const cli = meow(`
 		},
 		tag: {
 			type: 'string'
+		},
+		gitTagVersion: {
+			type: 'boolean',
+			default: true
 		},
 		yarn: {
 			type: 'boolean',

--- a/index.js
+++ b/index.js
@@ -101,7 +101,15 @@ module.exports = (input, opts) => {
 		{
 			title: 'Bumping version using npm',
 			enabled: () => opts.yarn === false,
-			task: () => exec('npm', ['version', input])
+			task: () => {
+				const args = ['version', input];
+
+				if (!opts.gitTagVersion) {
+					args.push('--no-git-tag-version');
+				}
+
+				return exec('npm', args);
+			}
 		}
 	]);
 
@@ -120,6 +128,10 @@ module.exports = (input, opts) => {
 
 					if (opts.tag) {
 						args.push('--tag', opts.tag);
+					}
+
+					if (!opts.gitTagVersion) {
+						args.push('--no-git-tag-version');
 					}
 
 					return exec('yarn', args);


### PR DESCRIPTION
Based on my proposal in #249, this PR would allow you to publish a package without also creating a git commit with tag. Since both yarn & npm have a way to disable this behavior through `--no-git-tag-version` I've reused this option name.

This is specifically for the scenario where you want to run a CI/CD build that publishes each build to npm, ideally with a timestamp instead of an automatically incrementing build number, i.e. `package@1.1.0-build-1519737350`. This has the benefit of giving other CI/CD packages the ability to consume your unstable npm package while it's going through various stages, (i.e. alpha -> beta -> release) without having to manually maintain and update the package version constraint.

Our specific use-case for this is a set-up with separate client and server packages (and teams) that get developed and released simultaneously and would keep `MAJOR.MINOR` synchronized. This approach would allow us to always be working with eachother's latest compatible CI packages in development.

Without an option like this each commit would be succeeded by a git-tag commit, effectively doubling the number of commits and creating a lot of noise.

This basically enables the inverse scenario of the current `--no-publish` option (publish to npm, not publish to git).

There's one issue: it leaves your git state dirty, as your `package.json` gets modified but never gets committed. In the context of a (containerized) CI build this is not an issue, but I can image that with a persistent repo it will involve a manual clean before doing another publish, or have `np` discard the modified `package.json` if it detects it's running with `--no-git-version`.

I'm just opening this PR to get the ball rolling, if you decide not to merge this, no worries, I've built my own release that we can use.

Thanks a lot for you work on this lib :)