### PR TITLE
Fix yarn version bump for private packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,16 @@ module.exports = (input, opts) => {
 
 	tasks.add([
 		{
+			title: 'Bumping version using Yarn',
+			enabled: () => opts.yarn === true,
+			skip: () => {
+				if (runPublish && !pkg.private) {
+					return 'Public package: version will be bumped using yarn publish.';
+				}
+			},
+			task: () => exec('yarn', ['version', '--new-version', input])
+		},
+		{
 			title: 'Bumping version using npm',
 			enabled: () => opts.yarn === false,
 			task: () => exec('npm', ['version', input])


### PR DESCRIPTION
This allows np to create a tag on a private package, it sort of reverts https://github.com/sindresorhus/np/pull/235.
For public packages, the tag will be created using yarn publish.

Private package:
```
$ ../np/cli.js 1.0.1
 ✔ Prerequisite check
 ✔ Git
 ✔ Cleanup
 ✔ Installing dependencies using Yarn
 ✔ Running tests using Yarn
 ✔ Bumping version using Yarn
 ↓ Publishing package using Yarn [skipped]
   → Private package: not publishing to Yarn.
 ✔ Pushing tags
```

Public package:
```
$ ../np/cli.js 1.0.2
 ✔ Prerequisite check
 ✔ Git
 ✔ Cleanup
 ✔ Installing dependencies using Yarn
 ✔ Running tests using Yarn
 ↓ Bumping version using Yarn [skipped]
   → Public package: version will be bumped using yarn publish.
 ✔ Publishing package using Yarn
 ✔ Pushing tags
```

---

cc @gpoole @ErisDS 