### PR TITLE
Exit with non-zero exit code on SIGINT

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -56,6 +56,11 @@ const cli = meow(`
 
 updateNotifier({pkg: cli.pkg}).notify();
 
+process.on("SIGINT", function () {
+  console.log('\nAborted!');
+  process.exit(100);
+});
+
 Promise
 	.resolve()
 	.then(() => {

--- a/cli.js
+++ b/cli.js
@@ -58,7 +58,7 @@ updateNotifier({pkg: cli.pkg}).notify();
 
 process.on('SIGINT', () => {
 	console.log('\nAborted!');
-	process.exit(100);
+	process.exit(1);
 });
 
 Promise

--- a/cli.js
+++ b/cli.js
@@ -56,9 +56,9 @@ const cli = meow(`
 
 updateNotifier({pkg: cli.pkg}).notify();
 
-process.on("SIGINT", function () {
-  console.log('\nAborted!');
-  process.exit(100);
+process.on('SIGINT', () => {
+	console.log('\nAborted!');
+	process.exit(100);
 });
 
 Promise


### PR DESCRIPTION
As I am a bit fan of not installing globally and love the Idea of enhancing the default `npm publish` with this nice tool, I added it to my `script.prepublishOnly` hook.

But when I testet my integration I didn't want to publish and aborted with ctrl+c. But the problem is, that np currently returns with exit code 0 in this case which in turn started publishing anyway, but without all the nice checks from np.

To avoid this I thought about catching the SIGINT in the cli and end the process with a non zero exit code. (just picked 100 before I saw that you are just exiting with 1 in an error case. I can change this to 1 as well or we leave them separate to distinguish them, as you prefer)

I think this makes it more convenient when integrating it in other scripts as well.
Any opinions of suggestions? 