### PR TITLE
Add ability to publish a subdirectory

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -49,7 +49,7 @@ const cli = meow(`
 		tag: {
 			type: 'string'
 		},
-		content: {
+		contents: {
 			type: 'string'
 		},
 		yarn: {

--- a/cli.js
+++ b/cli.js
@@ -49,12 +49,12 @@ const cli = meow(`
 		tag: {
 			type: 'string'
 		},
-		contents: {
-			type: 'string'
-		},
 		yarn: {
 			type: 'boolean',
 			default: hasYarn()
+		},
+		contents: {
+			type: 'string'
 		}
 	}
 });

--- a/cli.js
+++ b/cli.js
@@ -22,14 +22,14 @@ const cli = meow(`
 	  --no-publish  Skips publishing
 	  --tag         Publish under a given dist-tag
 	  --no-yarn     Don't use Yarn
-	  --content     Tarball or folder to be published
+	  --contents    Subdirectory to publish
 
 	Examples
 	  $ np
 	  $ np patch
 	  $ np 1.0.2
 	  $ np 1.0.2-beta.3 --tag=beta
-	  $ np 1.0.2-beta.3 --tag=beta --content=dist
+	  $ np 1.0.2-beta.3 --tag=beta --contents=dist
 `, {
 	flags: {
 		anyBranch: {

--- a/cli.js
+++ b/cli.js
@@ -22,12 +22,14 @@ const cli = meow(`
 	  --no-publish  Skips publishing
 	  --tag         Publish under a given dist-tag
 	  --no-yarn     Don't use Yarn
+	  --content     Tarball or folder to be published
 
 	Examples
 	  $ np
 	  $ np patch
 	  $ np 1.0.2
 	  $ np 1.0.2-beta.3 --tag=beta
+	  $ np 1.0.2-beta.3 --tag=beta --content=dist
 `, {
 	flags: {
 		anyBranch: {
@@ -45,6 +47,9 @@ const cli = meow(`
 			default: true
 		},
 		tag: {
+			type: 'string'
+		},
+		content: {
 			type: 'string'
 		},
 		yarn: {

--- a/index.js
+++ b/index.js
@@ -118,8 +118,8 @@ module.exports = (input, opts) => {
 				task: () => {
 					const args = ['publish'];
 
-					if (opts.content) {
-						args.push(opts.content);
+					if (opts.contents) {
+						args.push(opts.contents);
 					}
 
 					args.push('--new-version', input);

--- a/index.js
+++ b/index.js
@@ -116,7 +116,13 @@ module.exports = (input, opts) => {
 					}
 				},
 				task: () => {
-					const args = ['publish', '--new-version', input];
+					const args = ['publish'];
+
+					if (opts.content) {
+						args.push(opts.content);
+					}
+
+					args.push('--new-version', input);
 
 					if (opts.tag) {
 						args.push('--tag', opts.tag);
@@ -133,7 +139,7 @@ module.exports = (input, opts) => {
 						return 'Private package: not publishing to npm.';
 					}
 				},
-				task: (ctx, task) => publish(task, opts.tag)
+				task: (ctx, task) => publish(task, opts)
 			}
 		]);
 	}

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -7,8 +7,8 @@ const chalk = require('chalk');
 const npmPublish = options => {
 	const args = ['publish'];
 
-	if (options.content) {
-		args.push(options.content);
+	if (options.contents) {
+		args.push(options.contents);
 	}
 
 	if (options.tag) {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -30,8 +30,7 @@ const handleError = (task, err, options, message) => {
 		return listrInput(message || 'Enter OTP:', {
 			done: otp => {
 				task.title = title;
-				options = Object.assign({otp}, options);
-				return npmPublish(options);
+				return npmPublish(Object.assign({otp}, options));
 			}
 		}).catch(err => handleError(task, err, options, 'OTP was incorrect, try again:'));
 	}

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -22,7 +22,7 @@ const npmPublish = options => {
 	return execa('npm', args);
 };
 
-const handleError = (task, err, tag, message) => {
+const handleError = (task, err, options, message) => {
 	if (err.stderr.includes('one-time pass')) {
 		const {title} = task;
 		task.title = `${title} ${chalk.yellow('(waiting for input…)')}`;
@@ -30,15 +30,15 @@ const handleError = (task, err, tag, message) => {
 		return listrInput(message || 'Enter OTP:', {
 			done: otp => {
 				task.title = title;
-				return npmPublish({tag, otp});
+				return npmPublish({...options, otp});
 			}
-		}).catch(err => handleError(task, err, tag, 'OTP was incorrect, try again:'));
+		}).catch(err => handleError(task, err, options, 'OTP was incorrect, try again:'));
 	}
 
 	return Observable.throw(err);
 };
 
 const publish = (task, options) => Observable.fromPromise(npmPublish(options))
-	.catch(err => handleError(task, err, options.tag));
+	.catch(err => handleError(task, err, options));
 
 module.exports = publish;

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -7,6 +7,10 @@ const chalk = require('chalk');
 const npmPublish = options => {
 	const args = ['publish'];
 
+	if (options.content) {
+		args.push(options.content);
+	}
+
 	if (options.tag) {
 		args.push('--tag', options.tag);
 	}
@@ -34,7 +38,7 @@ const handleError = (task, err, tag, message) => {
 	return Observable.throw(err);
 };
 
-const publish = (task, tag) => Observable.fromPromise(npmPublish({tag}))
-	.catch(err => handleError(task, err, tag));
+const publish = (task, options) => Observable.fromPromise(npmPublish(options))
+	.catch(err => handleError(task, err, options));
 
 module.exports = publish;

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -39,6 +39,6 @@ const handleError = (task, err, tag, message) => {
 };
 
 const publish = (task, options) => Observable.fromPromise(npmPublish(options))
-	.catch(err => handleError(task, err, options));
+	.catch(err => handleError(task, err, options.tag));
 
 module.exports = publish;

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -30,7 +30,8 @@ const handleError = (task, err, options, message) => {
 		return listrInput(message || 'Enter OTP:', {
 			done: otp => {
 				task.title = title;
-				return npmPublish({...options, otp});
+				options = Object.assign({otp}, options);
+				return npmPublish(options);
 			}
 		}).catch(err => handleError(task, err, options, 'OTP was incorrect, try again:'));
 	}

--- a/readme.md
+++ b/readme.md
@@ -46,12 +46,14 @@ $ np --help
     --no-publish  Skips publishing
     --tag         Publish under a given dist-tag
     --no-yarn     Don't use Yarn
+    --content     Tarball or folder to be published
 
   Examples
     $ np
     $ np patch
     $ np 1.0.2
     $ np 1.0.2-beta.3 --tag=beta
+    $ np 1.0.2-beta.3 --tag=beta --content=dist
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -46,14 +46,14 @@ $ np --help
     --no-publish  Skips publishing
     --tag         Publish under a given dist-tag
     --no-yarn     Don't use Yarn
-    --content     Tarball or folder to be published
+    --contents    Subdirectory to publish
 
   Examples
     $ np
     $ np patch
     $ np 1.0.2
     $ np 1.0.2-beta.3 --tag=beta
-    $ np 1.0.2-beta.3 --tag=beta --content=dist
+    $ np 1.0.2-beta.3 --tag=beta --contents=dist
 ```
 
 


### PR DESCRIPTION
### About this pull request

This pull request is a way to solve [this issue](https://github.com/sindresorhus/np/issues/264). With these changes, the `np` users can specify the current folder or tarball to be published as a package via `--content` flag.

Example

```bash
$ np 1.0.2-beta.3 --tag=beta --content=dist 
```


### Sharing some points

- NodeJS `path` functions are not required since `np` runs based on the current `process.cwd()`;
- Checked with NPM and Yarn and in both approaches are working properly;

---

Fixes #264