### PR TITLE
MOD: add third npm tool

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -47,6 +47,10 @@ const cli = meow(`
 		tag: {
 			type: 'string'
 		},
+    npmTool: {
+      type: 'string',
+      default: 'npm'
+    },
 		yarn: {
 			type: 'boolean',
 			default: hasYarn()

--- a/index.js
+++ b/index.js
@@ -75,9 +75,9 @@ module.exports = (input, opts) => {
 				})
 			},
 			{
-				title: 'Installing dependencies using npm',
+				title: 'Installing dependencies using npmTool',
 				enabled: () => opts.yarn === false,
-				task: () => exec('npm', ['install', '--no-package-lock', '--no-production'])
+				task: () => exec(opts.npmTool, ['install', '--no-package-lock', '--no-production'])
 			}
 		]);
 	}
@@ -85,9 +85,9 @@ module.exports = (input, opts) => {
 	if (runTests) {
 		tasks.add([
 			{
-				title: 'Running tests using npm',
+				title: 'Running tests using npmTool',
 				enabled: () => opts.yarn === false,
-				task: () => exec('npm', ['test'])
+				task: () => exec(opts.npmTool, ['test'])
 			},
 			{
 				title: 'Running tests using Yarn',
@@ -109,9 +109,9 @@ module.exports = (input, opts) => {
 			task: () => exec('yarn', ['version', '--new-version', input])
 		},
 		{
-			title: 'Bumping version using npm',
+			title: 'Bumping version using npmTool',
 			enabled: () => opts.yarn === false,
-			task: () => exec('npm', ['version', input])
+			task: () => exec(opts.npmTool, ['version', input])
 		}
 	]);
 
@@ -131,19 +131,18 @@ module.exports = (input, opts) => {
 					if (opts.tag) {
 						args.push('--tag', opts.tag);
 					}
-
 					return exec('yarn', args);
 				}
 			},
 			{
-				title: 'Publishing package using npm',
+				title: 'Publishing package using npmTool',
 				enabled: () => opts.yarn === false,
 				skip: () => {
 					if (pkg.private) {
 						return 'Private package: not publishing to npm.';
 					}
 				},
-				task: (ctx, task) => publish(task, opts.tag)
+				task: (ctx, task) => publish(task, opts)
 			}
 		]);
 	}

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -15,7 +15,7 @@ const npmPublish = options => {
 		args.push('--otp', options.otp);
 	}
 
-	return execa('npm', args);
+	return execa(options.npmTool, args);
 };
 
 const handleError = (task, err, tag, message) => {
@@ -34,7 +34,7 @@ const handleError = (task, err, tag, message) => {
 	return Observable.throw(err);
 };
 
-const publish = (task, tag) => Observable.fromPromise(npmPublish({tag}))
-	.catch(err => handleError(task, err, tag));
+const publish = (task, opts) => Observable.fromPromise(npmPublish(opts))
+	.catch(err => handleError(task, err, opts.tag));
 
 module.exports = publish;


### PR DESCRIPTION
Add support to third NPM Tools, such as CNPM.
It's useless to config the registry in the 'publishConfig' , because the third NPM has different with the official NPM.

Tips: 
The NPMTool must use as a cli not  a alias 