### PR TITLE
Fix dynamic commit hash abbreviation length

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -38,9 +38,9 @@ function printCommitLog(repositoryUrl) {
 
 			const history = result.split('\n')
 				.map(commit => {
-					const commitParts = commit.match(/^(.+)\s([a-f\d]{7})$/);
-					const commitMessage = util.linkifyIssues(repositoryUrl, commitParts[1]);
-					const commitId = util.linkifyCommit(repositoryUrl, commitParts[2]);
+					const splitIndex = commit.lastIndexOf(' ');
+					const commitMessage = util.linkifyIssues(repositoryUrl, commit.substring(0, splitIndex));
+					const commitId = util.linkifyCommit(repositoryUrl, commit.substring(splitIndex + 1));
 
 					return `- ${commitMessage}  ${commitId}`;
 				})


### PR DESCRIPTION
For "big" projects (that have a lot of commits), Git commit abbreviation hash have a dynamic length (contrary to "small" projects that have a fixed length of 7):
[Commit introducing this change in the Git source code](https://github.com/git/git/commit/e6c587c733b4634030b353f4024794b08bc86892)

For example, running np on a "big" project (like the Vue.js source code) yields this error:

> np

Publish a new version of vue (current: 2.5.17-beta.0)

✖ Cannot read property '1' of null

As the command
> git log --format='%s %h' 19552a82a636910f4595937141557305ab5d434e..HEAD

returns lines with a hash of 8 characters:

```
chore(package.json): Add sideEffects: false field in package.json (#8099) 5e3823a5
chore: new sponsor 654e5f15
chore(typo): no dots at the end of the comments (#8087) 1abb944a
```

Instead of using a regex with a fixed length of 7 for the commit hash, we can use [lastIndexOf](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/String/lastIndexOf) to find the last space character to split between the commit message and the hash.
That way, it works for both "small" and "big" projects.