### PR TITLE
Do not fail if repository is not hosed on GitHub - fixes #273

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -55,7 +55,13 @@ function printCommitLog(repositoryUrl) {
 module.exports = options => {
 	const pkg = util.readPkg();
 	const oldVersion = pkg.version;
-	const repositoryUrl = pkg.repository && githubUrlFromGit(pkg.repository.url);
+	let repositoryUrl;
+
+	try {
+		repositoryUrl = pkg.repository && githubUrlFromGit(pkg.repository.url);
+	} catch (err) {
+		// Parsing might fail if the repository is not hosed on GitHub. (See https://github.com/sindresorhus/np/issues/273)
+	}
 
 	console.log(`\nPublish a new version of ${chalk.bold.magenta(pkg.name)} ${chalk.dim(`(current: ${oldVersion})`)}\n`);
 


### PR DESCRIPTION
I believe this PR should solve #273. Should test it though as I'm a bit in a rush right now :).

@despairblue Care to try out this PR on one of your repositories?