### PR TITLE
Ensure all tasks honor the `--contents` flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = (input, opts) => {
 	const runCleanup = opts.cleanup && !opts.yolo;
 	const runPublish = opts.publish;
 	const pkg = util.readPkg(opts.contents);
+	const workingDirectory = path.join(process.cwd(), opts.contents || '');
 
 	const tasks = new Listr([
 		{
@@ -129,7 +130,7 @@ module.exports = (input, opts) => {
 		{
 			title: 'Bumping version using npm',
 			enabled: () => opts.yarn === false && opts.contents,
-			task: () => exec('npm', ['version', input], {cwd: path.join(process.cwd(), opts.contents)})
+			task: () => exec('npm', ['version', input], {cwd: workingDirectory})
 		},
 		{
 			title: 'Commiting package changes',
@@ -188,6 +189,6 @@ module.exports = (input, opts) => {
 	});
 
 	return tasks.run()
-		.then(() => readPkgUp({cwd: path.join(process.cwd(), opts.contents)}))
+		.then(() => readPkgUp({cwd: workingDirectory}))
 		.then(result => result.pkg);
 };

--- a/index.js
+++ b/index.js
@@ -126,18 +126,23 @@ module.exports = (input, opts) => {
 			title: 'Bumping version using npm',
 			enabled: () => opts.yarn === false,
 			task: () => exec('npm', ['version', input], {cwd: workingDirectory})
-		},
-		{
-			title: 'Commiting package changes',
-			enabled: () => opts.contents,
-			task: () => exec('git', ['commit', `-am ${input}`])
-		},
-		{
-			title: 'Creating git tag',
-			enabled: () => opts.contents,
-			task: () => exec('git', ['tag', '-a', `v${input}`, '-m', `"${input}"`])
 		}
 	]);
+
+	if (opts.contents) {
+		tasks.add([
+			{
+				title: 'Commiting package changes',
+				enabled: () => opts.contents,
+				task: () => exec('git', ['commit', `-am ${input}`])
+			},
+			{
+				title: 'Creating git tag',
+				enabled: () => opts.contents,
+				task: () => exec('git', ['tag', '-a', `v${input}`, '-m', `"${input}"`])
+			}
+		]);
+	}
 
 	if (runPublish) {
 		tasks.add([

--- a/index.js
+++ b/index.js
@@ -124,12 +124,7 @@ module.exports = (input, opts) => {
 		},
 		{
 			title: 'Bumping version using npm',
-			enabled: () => opts.yarn === false && !opts.contents,
-			task: () => exec('npm', ['version', input])
-		},
-		{
-			title: 'Bumping version using npm',
-			enabled: () => opts.yarn === false && opts.contents,
+			enabled: () => opts.yarn === false,
 			task: () => exec('npm', ['version', input], {cwd: workingDirectory})
 		},
 		{

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ module.exports = (input, opts) => {
 		{
 			title: 'Bumping version using npm',
 			enabled: () => opts.yarn === false && opts.contents,
-			task: () => exec('npm', ['version', input], { cwd: path.join(process.cwd(), opts.contents) })
+			task: () => exec('npm', ['version', input], {cwd: path.join(process.cwd(), opts.contents)})
 		},
 		{
 			title: 'Commiting package changes',
@@ -188,6 +188,6 @@ module.exports = (input, opts) => {
 	});
 
 	return tasks.run()
-		.then(() => readPkgUp({ cwd: path.join(process.cwd(), opts.contents) }))
+		.then(() => readPkgUp({cwd: path.join(process.cwd(), opts.contents)}))
 		.then(result => result.pkg);
 };

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -53,7 +53,7 @@ function printCommitLog(repositoryUrl) {
 }
 
 module.exports = options => {
-	const pkg = util.readPkg();
+	const pkg = util.readPkg(options.contents);
 	const oldVersion = pkg.version;
 	const repositoryUrl = pkg.repository && githubUrlFromGit(pkg.repository.url);
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,11 +1,11 @@
 'use strict';
+const path = require('path');
 const readPkgUp = require('read-pkg-up');
 const issueRegex = require('issue-regex');
 const terminalLink = require('terminal-link');
-const path = require('path');
 
 exports.readPkg = (contents = '') => {
-	const {pkg} = readPkgUp.sync({ cwd: path.join(process.cwd(), contents) });
+	const {pkg} = readPkgUp.sync({cwd: path.join(process.cwd(), contents)});
 
 	if (!pkg) {
 		throw new Error(`No package.json found. Make sure you're in the correct project.`);

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,9 +2,10 @@
 const readPkgUp = require('read-pkg-up');
 const issueRegex = require('issue-regex');
 const terminalLink = require('terminal-link');
+const path = require('path');
 
-exports.readPkg = () => {
-	const {pkg} = readPkgUp.sync();
+exports.readPkg = (contents = '') => {
+	const {pkg} = readPkgUp.sync({ cwd: path.join(process.cwd(), contents) });
 
 	if (!pkg) {
 		throw new Error(`No package.json found. Make sure you're in the correct project.`);


### PR DESCRIPTION
I was pretty excited by the recent addition of the `--contents` flag as it seemed to do exactly what I was after - publish a package that's in a subdirectory of another project.

Unfortunately upon trying it I noticed only the publish step honoured the `--contents` flag and all other `np` tasks still used and mutated the package.json in the root directory. 

This change fixes that and ensure that all commands read and mutate from the package.json in the directory provided with `--contents`.

Due to how `npm version` works I had to re-implement the git commit / tagging logic that is usually handled as there is no `.git` folder in subdirectories. I'm unsure about doing this. It's fine for my usecase but not sure it will suit everyone - would appreciate a second opinion. Maybe this should be an additional flag?