### PR TITLE
Add comparison link under commits

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -35,20 +35,26 @@ function printCommitLog(repositoryUrl) {
 			if (!result) {
 				return false;
 			}
+			return execa.stdout('git', ['describe', '--abbrev=0'])
+				.then(tagName => {
+					const history = result.split('\n')
+						.map(commit => {
+							const splitIndex = commit.lastIndexOf(' ');
+							const commitMessage = util.linkifyIssues(repositoryUrl, commit.substring(0, splitIndex));
+							const commitId = util.linkifyCommit(repositoryUrl, commit.substring(splitIndex + 1));
 
-			const history = result.split('\n')
-				.map(commit => {
-					const splitIndex = commit.lastIndexOf(' ');
-					const commitMessage = util.linkifyIssues(repositoryUrl, commit.substring(0, splitIndex));
-					const commitId = util.linkifyCommit(repositoryUrl, commit.substring(splitIndex + 1));
+							return `- ${commitMessage}  ${commitId}`;
+						})
+						.join('\n');
 
-					return `- ${commitMessage}  ${commitId}`;
-				})
-				.join('\n');
+					console.log(`${chalk.bold('Commits:')}\n${history}\n`);
 
-			console.log(`${chalk.bold('Commits:')}\n${history}\n`);
+					const commitRange = util.linkifyCommitRange(repositoryUrl, `${tagName}...master`);
 
-			return true;
+					console.log(`${chalk.bold('Commit Range:')}\n${commitRange}\n`);
+
+					return true;
+				});
 		});
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -36,3 +36,11 @@ exports.linkifyCommit = (url, commit) => {
 
 	return terminalLink(commit, `${url}/commit/${commit}`);
 };
+
+exports.linkifyCommitRange = (url, commitRange) => {
+	if (!(url && terminalLink.isSupported)) {
+		return commitRange;
+	}
+
+	return terminalLink(commitRange, `${url}/compare/${commitRange}`);
+};


### PR DESCRIPTION
If no tags are found, `git describe` will return an error, causing the program to exit. From my testing and understanding, this wont happen because of
```
if (!result) {  
  return false;  
}
```
but I am not completely sure. I would appreciate any feedback.

---

Fixes #283