### PR TITLE
feat: add --no-verify option to git push

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,6 +23,7 @@ const cli = meow(`
 	  --tag         Publish under a given dist-tag
 	  --no-yarn     Don't use Yarn
 	  --contents    Subdirectory to publish
+	  --no-verify   Skip git hooks on push
 
 	Examples
 	  $ np
@@ -55,6 +56,10 @@ const cli = meow(`
 		},
 		contents: {
 			type: 'string'
+		},
+		verify: {
+			type: 'boolean',
+			default: true
 		}
 	}
 });

--- a/index.js
+++ b/index.js
@@ -168,7 +168,15 @@ module.exports = (input, opts) => {
 
 	tasks.add({
 		title: 'Pushing tags',
-		task: () => exec('git', ['push', '--follow-tags'])
+		task: () => {
+			const args = ['push', '--follow-tags'];
+
+			if (!opts.verify) {
+				args.push('--no-verify');
+			}
+
+			return exec('git', args);
+		}
 	});
 
 	return tasks.run()

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ $ np --help
     --tag         Publish under a given dist-tag
     --no-yarn     Don't use Yarn
     --contents    Subdirectory to publish
+    --no-verify   Skip git hooks on push
 
   Examples
     $ np


### PR DESCRIPTION
skip git hooks when pushing tags

**use case**
I have git hooks setup to run tests before pushing
I use np to publish
np runs tests before pushing

**problem**
tests are run twice

*tests are run twice, first by np, second by git push hooks*