### PR TITLE
Add standard-version support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,13 +16,15 @@ const cli = meow(`
 	    ${version.SEMVER_INCREMENTS.join(' | ')} | 1.2.3
 
 	Options
-	  --any-branch  Allow publishing from any branch
-	  --no-cleanup  Skips cleanup of node_modules
-	  --yolo        Skips cleanup and testing
-	  --no-publish  Skips publishing
-	  --tag         Publish under a given dist-tag
-	  --no-yarn     Don't use Yarn
-	  --contents    Subdirectory to publish
+	  --any-branch        Allow publishing from any branch
+	  --no-cleanup        Skips cleanup of node_modules
+	  --yolo              Skips cleanup and testing
+	  --no-publish        Skips publishing
+	  --tag               Publish under a given dist-tag
+	  --no-yarn           Don't use Yarn
+	  --contents          Subdirectory to publish
+	  --standard-version  Use standard-version
+	  --changelog-file    Changelog file to be updated by standard-version
 
 	Examples
 	  $ np
@@ -55,6 +57,12 @@ const cli = meow(`
 		},
 		contents: {
 			type: 'string'
+		},
+		standardVersion: {
+			type: 'boolean'
+		},
+		changelogFile: {
+			type: 'string'
 		}
 	}
 });
@@ -69,6 +77,12 @@ process.on('SIGINT', () => {
 Promise
 	.resolve()
 	.then(() => {
+		if (cli.flags.standardVersion) {
+			return Object.assign({}, cli.flags, {
+				confirm: true
+			});
+		}
+
 		if (cli.input.length > 0) {
 			return Object.assign({}, cli.flags, {
 				confirm: true,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"rxjs": "^6.2.0",
 		"semver": "^5.2.0",
 		"split": "^1.0.0",
+		"standard-version": "^4.4.0",
 		"terminal-link": "^1.1.0",
 		"update-notifier": "^2.1.0"
 	},

--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,10 @@ $ npm install --save-dev branchsite
 }
 ```
 
+### Publish using standard-version
+
+To publish using [`standard-version`](https://github.com/conventional-changelog/standard-version), use the `--standard-version` flag. This will update/generate the changelog file along with bumping the versions. To specify the changelog input file, use the `--changelog-file` flag.
+
 ### Initial version
 
 For new packages, start the `version` field in package.json at `0.0.0` and let `np` bump it to `1.0.0` or `0.1.0` when publishing.


### PR DESCRIPTION
This adds support for a `--standard-version` CLI flag that replaces the `npm/yarn version` step with the [`standard-version`](https://github.com/conventional-changelog/standard-version) command.

It's basically the same as `npm version` except that after bumping the version, it updates the changelog and adds that to the commit as well. It also figures out which version bump to use based on the commit messages, so the whole UI part is skipped.

There is also a `--changelog-file` CLI flag that allows to tell `standard-version` which input file to use (cause I like `changelog.md` rather than `CHANGELOG.md`... doesn't need to shout at me :nerd_face:).

Kind of closes #61, I think.

BTW I managed to successfully publish a package with this, but didn't test in combination with `yarn`.