### PR TITLE
Default to not publish scoped packages publicly

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -154,7 +154,8 @@ module.exports = async (options, pkg) => {
 			type: 'confirm',
 			name: 'publishScoped',
 			when: isScoped(pkg.name) && !options.exists,
-			message: `This scoped repo ${chalk.bold.magenta(pkg.name)} hasn't been published. Do you want to publish it publicly?`
+			message: `This scoped repo ${chalk.bold.magenta(pkg.name)} hasn't been published. Do you want to publish it publicly?`,
+			default: false
 		}
 	];
 


### PR DESCRIPTION
The newly introduced question of whether to publish scoped packages publicly or not has a dangerous default for those of us who use scoped packages internally.

Just as npm itself defaults to publishing scoped packages privately, so should `np`.

An accidental public publish is not that easy to revert and can cause quite some problems, depending on what code it involved.