### PR TITLE
Remove npm version check

### DIFF
--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -89,17 +89,6 @@ module.exports = (input, pkg, options) => {
 			}
 		},
 		{
-			title: 'Check npm version',
-			skip: () => version.isVersionLower('6.0.0', process.version),
-			task: async () => {
-				const versions = JSON.parse(await execa.stdout('npm', ['version', '--json']));
-
-				if (!version.satisfies(versions.npm, '>=2.15.8 <3.0.0 || >=3.10.1')) {
-					throw new Error(`npm@${versions.npm} has known issues publishing when running Node.js 6. Please upgrade npm or downgrade Node and publish again. https://github.com/npm/npm/issues/5082`);
-				}
-			}
-		},
-		{
 			title: 'Check git tag existence',
 			task: async () => {
 				await execa('git', ['fetch']);

--- a/lib/version.js
+++ b/lib/version.js
@@ -25,13 +25,3 @@ exports.isVersionGreater = (oldVersion, newVersion) => {
 
 	return semver.gt(newVersion, oldVersion);
 };
-
-exports.isVersionLower = (oldVersion, newVersion) => {
-	if (!isValidVersion(newVersion)) {
-		throw new Error('Version should be a valid semver version.');
-	}
-
-	return semver.lt(newVersion, oldVersion);
-};
-
-exports.satisfies = (version, range) => semver.satisfies(version, range);

--- a/test/version.js
+++ b/test/version.js
@@ -83,34 +83,3 @@ test('version.isVersionGreater', t => {
 	t.true(version.isVersionGreater('1.0.0', '2.0.0-0'));
 	t.true(version.isVersionGreater('1.0.0', '2.0.0-beta'));
 });
-
-test('version.isVersionLower', t => {
-	const message = 'Version should be a valid semver version.';
-
-	t.throws(() => version.isVersionLower('1.0.0', 'patch'), message);
-	t.throws(() => version.isVersionLower('1.0.0', 'patchxxx'), message);
-	t.throws(() => version.isVersionLower('1.0.0', '1.0.0.0'), message);
-
-	t.true(version.isVersionLower('1.0.0', '0.0.1'));
-	t.true(version.isVersionLower('1.0.0', '0.1.0'));
-	t.true(version.isVersionLower('1.0.0', '1.0.0-0'));
-	t.true(version.isVersionLower('1.0.0', '1.0.0-beta'));
-	t.true(version.isVersionLower('6.0.0', '4.4.3'));
-
-	t.false(version.isVersionLower('1.0.0', '1.0.0'));
-	t.false(version.isVersionLower('1.0.0', '1.0.1'));
-	t.false(version.isVersionLower('1.0.0', '1.1.0'));
-	t.false(version.isVersionLower('1.0.0', '2.0.0'));
-	t.false(version.isVersionLower('6.0.0', '6.7.0'));
-
-	t.false(version.isVersionLower('1.0.0', '2.0.0-0'));
-	t.false(version.isVersionLower('1.0.0', '2.0.0-beta'));
-});
-
-test('version.satisfies', t => {
-	t.true(version.satisfies('2.15.8', '>=2.15.8 <3.0.0 || >=3.10.1'));
-	t.true(version.satisfies('2.99.8', '>=2.15.8 <3.0.0 || >=3.10.1'));
-	t.true(version.satisfies('3.10.1', '>=2.15.8 <3.0.0 || >=3.10.1'));
-	t.false(version.satisfies('3.0.0', '>=2.15.8 <3.0.0 || >=3.10.1'));
-	t.false(version.satisfies('3.10.0', '>=2.15.8 <3.0.0 || >=3.10.1'));
-});


### PR DESCRIPTION
The current Node.js version check (which is used to determine whether to skip the npm version check) is actually the wrong way around:

https://github.com/sindresorhus/np/blob/cec8e001794170db18d6c9cb468644d97441e697/lib/prerequisite.js#L93

For example, `version.isVersionLower('6.0.0', 'v11.6.0')` returns `false`, therefore *not* skipping the following npm version check:

https://github.com/sindresorhus/np/blob/cec8e001794170db18d6c9cb468644d97441e697/lib/prerequisite.js#L97

Since most installations nowadays include a newer npm version, the error was probably rarely thrown (even though the task ran on newer Node.js versions). However, Node.js v11.6.0 includes npm v6.5.0-next.0, a pre-release version. [Pre-release versions do not satisfy by default](https://github.com/npm/node-semver#prerelease-tags) which means that the above check fails and the error is thrown.

Instead of fixing the actual error, I’ve decided to remove the whole npm version check since [`np` requires Node.js v8 by now](https://github.com/sindresorhus/np/commit/223ba6bf1787e2d864a94c3ad53a1446cff6b482) (and won’t actually run on Node.js v6).

Fixes #309.