### PR TITLE
Skip npm name check when `--no-publish` is passed

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -71,7 +71,7 @@ process.on('SIGINT', () => {
 (async () => {
 	const pkg = util.readPkg();
 
-	const isAvailable = (cli.flags.publish ? await npmName(pkg.name) : false);
+	const isAvailable = cli.flags.publish ? await npmName(pkg.name) : false;
 
 	const options = cli.input.length > 0 ?
 		{

--- a/cli.js
+++ b/cli.js
@@ -70,8 +70,12 @@ process.on('SIGINT', () => {
 
 (async () => {
 	const pkg = util.readPkg();
-	const isAvailable = await npmName(pkg.name);
-
+	let isAvailable;
+	if (cli.flags.publish) {
+		isAvailable = await npmName(pkg.name);
+	} else {
+		isAvailable = cli.flags.publish;
+	}
 	const options = cli.input.length > 0 ?
 		{
 			...cli.flags,

--- a/cli.js
+++ b/cli.js
@@ -70,12 +70,9 @@ process.on('SIGINT', () => {
 
 (async () => {
 	const pkg = util.readPkg();
-	let isAvailable;
-	if (cli.flags.publish) {
-		isAvailable = await npmName(pkg.name);
-	} else {
-		isAvailable = cli.flags.publish;
-	}
+
+	const isAvailable = (cli.flags.publish ? await npmName(pkg.name) : false);
+
 	const options = cli.input.length > 0 ?
 		{
 			...cli.flags,

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -153,7 +153,7 @@ module.exports = async (options, pkg) => {
 		{
 			type: 'confirm',
 			name: 'publishScoped',
-			when: isScoped(pkg.name) && !options.exists,
+			when: isScoped(pkg.name) && !options.exists && options.publish,
 			message: `This scoped repo ${chalk.bold.magenta(pkg.name)} hasn't been published. Do you want to publish it publicly?`,
 			default: false
 		}


### PR DESCRIPTION
Added the check for no-publish to be only triggered when publish is true. 

I Would like to add the skip name check as another flag personally. In case people still choose to publish packages.