### PR TITLE
Move all Git utility commands to `lib/git-util.js`

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const pkgDir = require('pkg-dir');
 const prerequisiteTasks = require('./lib/prerequisite');
 const gitTasks = require('./lib/git');
 const util = require('./lib/util');
-const {hasUpstream} = require('./lib/git-util');
+const git = require('./lib/git-util');
 const publish = require('./lib/publish');
 
 const exec = (cmd, args) => {
@@ -150,8 +150,8 @@ module.exports = async (input = 'patch', options) => {
 
 	tasks.add({
 		title: 'Pushing tags',
-		skip: async () => !(await hasUpstream()),
-		task: () => exec('git', ['push', '--follow-tags'])
+		skip: async () => !(await git.hasUpstream()),
+		task: () => git.push()
 	});
 
 	await tasks.run();

--- a/lib/git-util.js
+++ b/lib/git-util.js
@@ -18,6 +18,67 @@ exports.latestTagOrFirstCommit = async () => {
 };
 
 exports.hasUpstream = async () => {
-	const {stdout} = await execa('git', ['status', '--short', '--branch', '--porcelain=2']);
+	const stdout = await execa.stdout('git', ['status', '--short', '--branch', '--porcelain=2']);
 	return /^# branch\.upstream [\w\-/]+$/m.test(stdout);
 };
+
+exports.currentBranch = () => execa.stdout('git', ['symbolic-ref', '--short', 'HEAD']);
+
+exports.isWorkingTreeClean = async () => {
+	try {
+		const status = await execa.stdout('git', ['status', '--porcelain']);
+		if (status !== '') {
+			return false;
+		}
+
+		return true;
+	} catch (_) {
+		return false;
+	}
+};
+
+exports.remoteHistoryClean = async () => {
+	let stdout;
+	try { // Gracefully handle no remote set up.
+		stdout = await execa.stdout('git', ['rev-list', '--count', '--left-only', '@{u}...HEAD']);
+	} catch (_) {}
+
+	if (stdout && stdout !== '0') {
+		return false;
+	}
+
+	return true;
+};
+
+exports.validRemote = async () => {
+	try {
+		await execa('git', ['ls-remote', 'origin', 'HEAD']);
+		return true;
+	} catch (error) {
+		return error.stderr.replace('fatal:', 'Git fatal error:');
+	}
+};
+
+exports.fetchRemote = () => execa('git', ['fetch']);
+
+exports.doesTagExist = async tagName => {
+	try {
+		const revInfo = await execa.stdout('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagName}`]);
+
+		if (revInfo) {
+			return new Error(`Git tag \`${tagName}\` already exists.`);
+		}
+
+		return false;
+	} catch (error) {
+		// Command fails with code 1 and no output if the tag does not exist, even though `--quiet` is provided
+		// https://github.com/sindresorhus/np/pull/73#discussion_r72385685
+		if (error.stdout !== '' || error.stderr !== '') {
+			return error;
+		}
+
+		return false;
+	}
+};
+
+exports.commitLog = start => execa.stdout('git', ['log', '--format=%s %h', `${start}..HEAD`]);

--- a/lib/git-util.js
+++ b/lib/git-util.js
@@ -60,7 +60,7 @@ exports.verifyRemoteIsValid = async () => {
 
 exports.fetchRemote = () => execa('git', ['fetch']);
 
-const tagExists = async tagName => {
+exports.tagExists = async tagName => {
 	try {
 		const {stdout: revInfo} = await execa('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagName}`]);
 
@@ -79,10 +79,9 @@ const tagExists = async tagName => {
 		return false;
 	}
 };
-exports.tagExists = tagExists;
 
 exports.verifyTagDoesntExist = async tagName => {
-	if (await tagExists(tagName)) {
+	if (await exports.tagExists(tagName)) {
 		throw new Error(`Git tag \`${tagName}\` already exists.`);
 	}
 };

--- a/lib/git-util.js
+++ b/lib/git-util.js
@@ -18,7 +18,7 @@ exports.latestTagOrFirstCommit = async () => {
 };
 
 exports.hasUpstream = async () => {
-	const stdout = await execa.stdout('git', ['status', '--short', '--branch', '--porcelain=2']);
+	const {stdout} = await execa('git', ['status', '--short', '--branch', '--porcelain=2']);
 	return /^# branch\.upstream [\w\-/]+$/m.test(stdout);
 };
 
@@ -26,7 +26,7 @@ exports.currentBranch = () => execa.stdout('git', ['symbolic-ref', '--short', 'H
 
 exports.isWorkingTreeClean = async () => {
 	try {
-		const status = await execa.stdout('git', ['status', '--porcelain']);
+		const {stdout: status} = await execa('git', ['status', '--porcelain']);
 		if (status !== '') {
 			return false;
 		}
@@ -37,36 +37,35 @@ exports.isWorkingTreeClean = async () => {
 	}
 };
 
-exports.remoteHistoryClean = async () => {
-	let stdout;
+exports.isRemoteHistoryClean = async () => {
+	let history;
 	try { // Gracefully handle no remote set up.
-		stdout = await execa.stdout('git', ['rev-list', '--count', '--left-only', '@{u}...HEAD']);
+		history = await execa.stdout('git', ['rev-list', '--count', '--left-only', '@{u}...HEAD']);
 	} catch (_) {}
 
-	if (stdout && stdout !== '0') {
+	if (history && history !== '0') {
 		return false;
 	}
 
 	return true;
 };
 
-exports.validRemote = async () => {
+exports.verifyRemoteIsValid = async () => {
 	try {
 		await execa('git', ['ls-remote', 'origin', 'HEAD']);
-		return true;
 	} catch (error) {
-		return error.stderr.replace('fatal:', 'Git fatal error:');
+		throw error.stderr.replace('fatal:', 'Git fatal error:');
 	}
 };
 
 exports.fetchRemote = () => execa('git', ['fetch']);
 
-exports.doesTagExist = async tagName => {
+const tagExists = async tagName => {
 	try {
-		const revInfo = await execa.stdout('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagName}`]);
+		const {stdout: revInfo} = await execa('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagName}`]);
 
 		if (revInfo) {
-			return new Error(`Git tag \`${tagName}\` already exists.`);
+			return true;
 		}
 
 		return false;
@@ -74,11 +73,18 @@ exports.doesTagExist = async tagName => {
 		// Command fails with code 1 and no output if the tag does not exist, even though `--quiet` is provided
 		// https://github.com/sindresorhus/np/pull/73#discussion_r72385685
 		if (error.stdout !== '' || error.stderr !== '') {
-			return error;
+			throw error;
 		}
 
 		return false;
 	}
 };
+exports.tagExists = tagExists;
 
-exports.commitLog = start => execa.stdout('git', ['log', '--format=%s %h', `${start}..HEAD`]);
+exports.verifyTagDoesntExist = async tagName => {
+	if (await tagExists(tagName)) {
+		throw new Error(`Git tag \`${tagName}\` already exists.`);
+	}
+};
+
+exports.commitLogFromRevision = revision => execa.stdout('git', ['log', '--format=%s %h', `${revision}..HEAD`]);

--- a/lib/git-util.js
+++ b/lib/git-util.js
@@ -24,6 +24,12 @@ exports.hasUpstream = async () => {
 
 exports.currentBranch = () => execa.stdout('git', ['symbolic-ref', '--short', 'HEAD']);
 
+exports.verifyCurrentBranchIsMaster = async () => {
+	if (await exports.currentBranch() !== 'master') {
+		throw new Error('Not on `master` branch. Use --any-branch to publish anyway.');
+	}
+};
+
 exports.isWorkingTreeClean = async () => {
 	try {
 		const {stdout: status} = await execa('git', ['status', '--porcelain']);
@@ -34,6 +40,12 @@ exports.isWorkingTreeClean = async () => {
 		return true;
 	} catch (_) {
 		return false;
+	}
+};
+
+exports.verifyWorkingTreeIsClean = async () => {
+	if (!(await exports.isWorkingTreeClean())) {
+		throw new Error('Unclean working tree. Commit or stash changes first.');
 	}
 };
 
@@ -50,17 +62,23 @@ exports.isRemoteHistoryClean = async () => {
 	return true;
 };
 
+exports.verifyRemoteHistoryIsClean = async () => {
+	if (!(await exports.isRemoteHistoryClean())) {
+		throw new Error('Remote history differs. Please pull changes.');
+	}
+};
+
 exports.verifyRemoteIsValid = async () => {
 	try {
 		await execa('git', ['ls-remote', 'origin', 'HEAD']);
 	} catch (error) {
-		throw error.stderr.replace('fatal:', 'Git fatal error:');
+		throw new Error(error.stderr.replace('fatal:', 'Git fatal error:'));
 	}
 };
 
-exports.fetchRemote = () => execa('git', ['fetch']);
+exports.fetch = () => execa('git', ['fetch']);
 
-exports.tagExists = async tagName => {
+exports.tagExistsOnRemote = async tagName => {
 	try {
 		const {stdout: revInfo} = await execa('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagName}`]);
 
@@ -72,18 +90,20 @@ exports.tagExists = async tagName => {
 	} catch (error) {
 		// Command fails with code 1 and no output if the tag does not exist, even though `--quiet` is provided
 		// https://github.com/sindresorhus/np/pull/73#discussion_r72385685
-		if (error.stdout !== '' || error.stderr !== '') {
-			throw error;
+		if (error.stdout === '' && error.stderr === '') {
+			return false;
 		}
 
-		return false;
+		throw error;
 	}
 };
 
-exports.verifyTagDoesntExist = async tagName => {
-	if (await exports.tagExists(tagName)) {
+exports.verifyTagDoesNotExistOnRemote = async tagName => {
+	if (await exports.tagExistsOnRemote(tagName)) {
 		throw new Error(`Git tag \`${tagName}\` already exists.`);
 	}
 };
 
 exports.commitLogFromRevision = revision => execa.stdout('git', ['log', '--format=%s %h', `${revision}..HEAD`]);
+
+exports.push = () => execa('git', ['push', '--follow-tags']);

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,33 +1,20 @@
 'use strict';
 const Listr = require('listr');
-const {currentBranch, isWorkingTreeClean, isRemoteHistoryClean} = require('./git-util');
+const git = require('./git-util');
 
 module.exports = options => {
 	const tasks = [
 		{
 			title: 'Check current branch',
-			task: async () => {
-				const branch = await currentBranch();
-				if (branch !== 'master') {
-					throw new Error('Not on `master` branch. Use --any-branch to publish anyway.');
-				}
-			}
+			task: () => git.verifyCurrentBranchIsMaster()
 		},
 		{
 			title: 'Check local working tree',
-			task: async () => {
-				if (!(await isWorkingTreeClean())) {
-					throw new Error('Unclean working tree. Commit or stash changes first.');
-				}
-			}
+			task: () => git.verifyWorkingTreeIsClean()
 		},
 		{
 			title: 'Check remote history',
-			task: async () => {
-				if (!(await isRemoteHistoryClean())) {
-					throw new Error('Remote history differs. Please pull changes.');
-				}
-			}
+			task: () => git.verifyRemoteHistoryIsClean()
 		}
 	];
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,6 +1,6 @@
 'use strict';
 const Listr = require('listr');
-const {currentBranch, isWorkingTreeClean, remoteHistoryClean} = require('./git-util');
+const {currentBranch, isWorkingTreeClean, isRemoteHistoryClean} = require('./git-util');
 
 module.exports = options => {
 	const tasks = [
@@ -24,7 +24,7 @@ module.exports = options => {
 		{
 			title: 'Check remote history',
 			task: async () => {
-				if (!(await remoteHistoryClean())) {
+				if (!(await isRemoteHistoryClean())) {
 					throw new Error('Remote history differs. Please pull changes.');
 				}
 			}

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,13 +1,13 @@
 'use strict';
-const execa = require('execa');
 const Listr = require('listr');
+const {currentBranch, isWorkingTreeClean, remoteHistoryClean} = require('./git-util');
 
 module.exports = options => {
 	const tasks = [
 		{
 			title: 'Check current branch',
 			task: async () => {
-				const {stdout: branch} = await execa('git', ['symbolic-ref', '--short', 'HEAD']);
+				const branch = await currentBranch();
 				if (branch !== 'master') {
 					throw new Error('Not on `master` branch. Use --any-branch to publish anyway.');
 				}
@@ -16,8 +16,7 @@ module.exports = options => {
 		{
 			title: 'Check local working tree',
 			task: async () => {
-				const {stdout: status} = await execa('git', ['status', '--porcelain']);
-				if (status !== '') {
+				if (!(await isWorkingTreeClean())) {
 					throw new Error('Unclean working tree. Commit or stash changes first.');
 				}
 			}
@@ -25,12 +24,7 @@ module.exports = options => {
 		{
 			title: 'Check remote history',
 			task: async () => {
-				let stdout;
-				try { // Gracefully handle no remote set up.
-					stdout = await execa.stdout('git', ['rev-list', '--count', '--left-only', '@{u}...HEAD']);
-				} catch (_) {}
-
-				if (stdout && stdout !== '0') {
+				if (!(await remoteHistoryClean())) {
 					throw new Error('Remote history differs. Please pull changes.');
 				}
 			}

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 const Listr = require('listr');
 const pTimeout = require('p-timeout');
 const version = require('./version');
-const {validRemote, fetchRemote, doesTagExist} = require('./git-util');
+const {verifyRemoteIsValid, fetchRemote, verifyTagDoesntExist} = require('./git-util');
 
 module.exports = (input, pkg, options) => {
 	const isExternalRegistry = typeof pkg.publishConfig === 'object' && typeof pkg.publishConfig.registry === 'string';
@@ -59,12 +59,7 @@ module.exports = (input, pkg, options) => {
 		},
 		{
 			title: 'Check git remote',
-			task: async () => {
-				const valid = await validRemote();
-				if (valid !== true) {
-					throw valid;
-				}
-			}
+			task: async () => verifyRemoteIsValid()
 		},
 		{
 			title: 'Validate version',
@@ -106,11 +101,7 @@ module.exports = (input, pkg, options) => {
 					tagPrefix = await getTagVersionPrefix();
 				} catch (_) {}
 
-				const tagExists = await doesTagExist(`${tagPrefix}${newVersion}`);
-
-				if (tagExists) {
-					throw tagExists;
-				}
+				await verifyTagDoesntExist(`${tagPrefix}${newVersion}`);
 			}
 		}
 	];

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 const Listr = require('listr');
 const pTimeout = require('p-timeout');
 const version = require('./version');
-const {verifyRemoteIsValid, fetchRemote, verifyTagDoesntExist} = require('./git-util');
+const git = require('./git-util');
 
 module.exports = (input, pkg, options) => {
 	const isExternalRegistry = typeof pkg.publishConfig === 'object' && typeof pkg.publishConfig.registry === 'string';
@@ -59,7 +59,7 @@ module.exports = (input, pkg, options) => {
 		},
 		{
 			title: 'Check git remote',
-			task: async () => verifyRemoteIsValid()
+			task: async () => git.verifyRemoteIsValid()
 		},
 		{
 			title: 'Validate version',
@@ -86,7 +86,7 @@ module.exports = (input, pkg, options) => {
 		{
 			title: 'Check git tag existence',
 			task: async () => {
-				await fetchRemote();
+				await git.fetch();
 
 				const getTagVersionPrefix = () => {
 					if (options.yarn) {
@@ -101,7 +101,7 @@ module.exports = (input, pkg, options) => {
 					tagPrefix = await getTagVersionPrefix();
 				} catch (_) {}
 
-				await verifyTagDoesntExist(`${tagPrefix}${newVersion}`);
+				await git.verifyTagDoesNotExistOnRemote(`${tagPrefix}${newVersion}`);
 			}
 		}
 	];

--- a/lib/prerequisite.js
+++ b/lib/prerequisite.js
@@ -3,6 +3,7 @@ const execa = require('execa');
 const Listr = require('listr');
 const pTimeout = require('p-timeout');
 const version = require('./version');
+const {validRemote, fetchRemote, doesTagExist} = require('./git-util');
 
 module.exports = (input, pkg, options) => {
 	const isExternalRegistry = typeof pkg.publishConfig === 'object' && typeof pkg.publishConfig.registry === 'string';
@@ -59,10 +60,9 @@ module.exports = (input, pkg, options) => {
 		{
 			title: 'Check git remote',
 			task: async () => {
-				try {
-					await execa('git', ['ls-remote', 'origin', 'HEAD']);
-				} catch (error) {
-					throw new Error(error.stderr.replace('fatal:', 'Git fatal error:'));
+				const valid = await validRemote();
+				if (valid !== true) {
+					throw valid;
 				}
 			}
 		},
@@ -91,7 +91,7 @@ module.exports = (input, pkg, options) => {
 		{
 			title: 'Check git tag existence',
 			task: async () => {
-				await execa('git', ['fetch']);
+				await fetchRemote();
 
 				const getTagVersionPrefix = () => {
 					if (options.yarn) {
@@ -106,18 +106,10 @@ module.exports = (input, pkg, options) => {
 					tagPrefix = await getTagVersionPrefix();
 				} catch (_) {}
 
-				try {
-					const {stdout: revInfo} = await execa.stdout('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagPrefix}${newVersion}`]);
+				const tagExists = await doesTagExist(`${tagPrefix}${newVersion}`);
 
-					if (revInfo) {
-						throw new Error(`Git tag \`${tagPrefix}${newVersion}\` already exists.`);
-					}
-				} catch (error) {
-					// Command fails with code 1 and no output if the tag does not exist, even though `--quiet` is provided
-					// https://github.com/sindresorhus/np/pull/73#discussion_r72385685
-					if (error.stdout !== '' || error.stderr !== '') {
-						throw error;
-					}
+				if (tagExists) {
+					throw tagExists;
 				}
 			}
 		}

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -5,7 +5,7 @@ const chalk = require('chalk');
 const githubUrlFromGit = require('github-url-from-git');
 const isScoped = require('is-scoped');
 const util = require('./util');
-const {latestTagOrFirstCommit} = require('./git-util');
+const {latestTagOrFirstCommit, commitLog} = require('./git-util');
 const version = require('./version');
 
 const prettyVersionDiff = (oldVersion, inc) => {
@@ -32,7 +32,7 @@ const prettyVersionDiff = (oldVersion, inc) => {
 
 const printCommitLog = async repoUrl => {
 	const latest = await latestTagOrFirstCommit();
-	const {stdout: log} = await execa('git', ['log', '--format=%s %h', `${latest}..HEAD`]);
+	const log = await commitLog(latest);
 
 	if (!log) {
 		return false;

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -5,13 +5,13 @@ const chalk = require('chalk');
 const githubUrlFromGit = require('github-url-from-git');
 const isScoped = require('is-scoped');
 const util = require('./util');
-const {latestTagOrFirstCommit, commitLogFromRevision} = require('./git-util');
+const git = require('./git-util');
 const version = require('./version');
 const prettyVersionDiff = require('./pretty-version-diff');
 
 const printCommitLog = async repoUrl => {
-	const latest = await latestTagOrFirstCommit();
-	const log = await commitLogFromRevision(latest);
+	const latest = await git.latestTagOrFirstCommit();
+	const log = await git.commitLogFromRevision(latest);
 
 	if (!log) {
 		return {

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -5,7 +5,7 @@ const chalk = require('chalk');
 const githubUrlFromGit = require('github-url-from-git');
 const isScoped = require('is-scoped');
 const util = require('./util');
-const {latestTagOrFirstCommit, commitLog} = require('./git-util');
+const {latestTagOrFirstCommit, commitLogFromRevision} = require('./git-util');
 const version = require('./version');
 
 const prettyVersionDiff = (oldVersion, inc) => {
@@ -32,7 +32,7 @@ const prettyVersionDiff = (oldVersion, inc) => {
 
 const printCommitLog = async repoUrl => {
 	const latest = await latestTagOrFirstCommit();
-	const log = await commitLog(latest);
+	const log = await commitLogFromRevision(latest);
 
 	if (!log) {
 		return false;


### PR DESCRIPTION
This follows up https://github.com/sindresorhus/np/pull/289#discussion_r246272308, #321 and #322.
Note that I didn't move [the `push` command](https://github.com/sindresorhus/np/blob/master/index.js#L154) to `git-util.js` since it uses [`exec`](https://github.com/sindresorhus/np/blob/master/index.js#L21).