### PR TITLE
 Improved name guessing by reading the package.json in the --contents dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
   - '10'
   - '8'
+os:
+ - linux
+ - windows
+ - osx

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && FORCE_HYPERLINK=1 ava"
+		"test": "xo && cross-env FORCE_HYPERLINK=1 ava"
 	},
 	"files": [
 		"source"
@@ -58,6 +58,7 @@
 	},
 	"devDependencies": {
 		"ava": "^1.1.0",
-		"xo": "^0.24.0"
+		"xo": "^0.24.0",
+		"cross-env": "^5.2.0"
 	}
 }

--- a/source/index.js
+++ b/source/index.js
@@ -31,7 +31,7 @@ const exec = (cmd, args) => {
 	).pipe(filter(Boolean));
 };
 
-module.exports = async (input = 'patch', options) => {
+module.exports = async (input = 'patch', options, providedPkg = null) => {
 	options = {
 		cleanup: true,
 		publish: true,
@@ -50,7 +50,7 @@ module.exports = async (input = 'patch', options) => {
 	const runTests = !options.yolo;
 	const runCleanup = options.cleanup && !options.yolo;
 	const runPublish = options.publish;
-	const pkg = util.readPkg();
+	const pkg = providedPkg || util.readPkg();
 	const pkgManager = options.yarn === true ? 'yarn' : 'npm';
 	const pkgManagerName = options.yarn === true ? 'Yarn' : 'npm';
 	const rootDir = pkgDir.sync();

--- a/source/util.js
+++ b/source/util.js
@@ -6,8 +6,8 @@ const execa = require('execa');
 const pMemoize = require('p-memoize');
 const ow = require('ow');
 
-exports.readPkg = () => {
-	const {pkg} = readPkgUp.sync();
+exports.readPkg = (cwd = null) => {
+	const {pkg} = cwd ? readPkgUp.sync({cwd}) : readPkgUp.sync();
 
 	if (!pkg) {
 		throw new Error('No package.json found. Make sure you\'re in the correct project.');


### PR DESCRIPTION
I currently cannot use `np` in a some of my projects because it forces me to have a `name` field in my `PROJECT/package.json`. I like to use a very special `package.json` setup though.

`PROJECT/package.json`
```json
{
  "version": "1.2.3",
  "author": {
	"name": "Jaid",
	"url": "github.com/Jaid"
  },
  "scripts": {
    "build": "webpack",
    "np": "npm run build && np --contents dist"
  }
}
```

`PROJECT/dist/package.json` (Auto generated with my currently in-development package.json-generator [publishimo](https://github.com/Jaid/publishimo))
```json
{
  "version": "1.2.3",
  "author": {
	"name": "Jaid",
	"url": "github.com/Jaid"
  },
  "license": "MIT",
  "main": "index.js",
  "name": "project",
  "description": "This is my project",
  "repository": "github:Jaid/project",
  "homepage": "https://github.com/Jaid/project#readme",
  "bugs": "https://github.com/Jaid/project/issues"
}
```

`np` errors with "package name required" when calling `await require("npm-name")(name)`, because it fails to fetch a name property from the `PROJECT/package.json` file.

In this patch:
- If argument `--contents dist` is given and `PROJECT/package.json` doesn't have a name field, also look for a name field in `PROJECT/dist/package.json`
- `cli.js` passes its `pkg` object to `index.js`, so the `package.json` files doesn't have to be read twice
- Added devDependency `cross-env`, because my Windows environment (sorry for that!) doesn't understand `FORCE_HYPERLINK=1 ava` natively
- Instructed Travis to also build and test on OSX and Windows