### PR TITLE
Check package.json engine version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && FORCE_HYPERLINK=1 ava"
+		"test": "xo && FORCE_HYPERLINK=1 ava && installed-check -d -e -n"
 	},
 	"files": [
 		"source"
@@ -58,6 +58,7 @@
 	},
 	"devDependencies": {
 		"ava": "^1.1.0",
+		"installed-check": "^2.2.0",
 		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
When running the tests, also check and ensure that the package.json engine version range for node isn't more permissive than that of its dependencies

Catches problems like #340

Uses my [installed-check](https://www.npmjs.com/package/installed-check) module with flags to not include dev dependencies in the check (`-d`), check the engine version range (`-e`) and not do the default behavior of checking whether installed modules matches the required version ranges defined in the package.json (`-n`)

This is expected to fail until the issue mentioned in #340 has been fixed, as this is a test to catch that error