### PR TITLE
Fix doing a prerelease as the first release

### DIFF
--- a/source/npm-util.js
+++ b/source/npm-util.js
@@ -50,7 +50,7 @@ exports.prereleaseTags = async packageName => {
 		tags = Object.keys(JSON.parse(stdout))
 			.filter(tag => tag !== 'latest');
 	} catch (error) {
-		if (((JSON.parse(error.stdout) || {}).error || {}).code  !== 'E404') {
+		if (((JSON.parse(error.stdout) || {}).error || {}).code !== 'E404') {
 			throw error;
 		}
 	}

--- a/source/npm-util.js
+++ b/source/npm-util.js
@@ -26,37 +26,16 @@ exports.username = async () => {
 	}
 };
 
-const checkExistance = async packageName => {
-	ow(packageName, ow.string);
-
-	let tags = [];
-	try {
-		await execa('npm', ['view', '--json', packageName, 'name']);
-	} catch (error) {
-		if (((JSON.parse(error.stdout) || {}).error || {}).code  === 'E404') {
-			return false
-		}
-    throw error;
-	}
-
-	return true;
-};
-
-exports.checkExistance = checkExistance;
-
 exports.collaborators = async packageName => {
 	ow(packageName, ow.string);
 
 	try {
 		return await execa.stdout('npm', ['access', 'ls-collaborators', packageName]);
 	} catch (error) {
-		try {
-			const exists = await checkExistance(packageName);
-
-			if (!exists) {
-				return false;
-			}
-		} catch (error) {}
+		// Ignore non-existing package error
+		if (error.stderr.includes('code E404')) {
+			return false;
+		}
 
 		throw error;
 	}

--- a/source/npm-util.js
+++ b/source/npm-util.js
@@ -26,16 +26,37 @@ exports.username = async () => {
 	}
 };
 
+const checkExistance = async packageName => {
+	ow(packageName, ow.string);
+
+	let tags = [];
+	try {
+		await execa('npm', ['view', '--json', packageName, 'name']);
+	} catch (error) {
+		if (((JSON.parse(error.stdout) || {}).error || {}).code  === 'E404') {
+			return false
+		}
+    throw error;
+	}
+
+	return true;
+};
+
+exports.checkExistance = checkExistance;
+
 exports.collaborators = async packageName => {
 	ow(packageName, ow.string);
 
 	try {
 		return await execa.stdout('npm', ['access', 'ls-collaborators', packageName]);
 	} catch (error) {
-		// Ignore non-existing package error
-		if (error.stderr.includes('code E404')) {
-			return false;
-		}
+		try {
+			const exists = await checkExistance(packageName);
+
+			if (!exists) {
+				return false;
+			}
+		} catch (error) {}
 
 		throw error;
 	}

--- a/source/npm-util.js
+++ b/source/npm-util.js
@@ -50,7 +50,7 @@ exports.prereleaseTags = async packageName => {
 		tags = Object.keys(JSON.parse(stdout))
 			.filter(tag => tag !== 'latest');
 	} catch (error) {
-		if (JSON.parse(error.stdout).code !== 'E404') {
+		if (((JSON.parse(error.stdout) || {}).error || {}).code  !== 'E404') {
 			throw error;
 		}
 	}


### PR DESCRIPTION
Despite #331 / #179 claiming to be fixed, I ran into exactly the same issue when trying to publish a new module's first version as a prerelease.

I took a look at the code and found that the check introduced in #331 checked `JSON.parse(error.stdout).code` rather than the correct ``JSON.parse(error.stdout).error.code`, which meant it never equaled `'E404'` (or npm has changed its format between that PR and my test, I used npm `6.7.0`)

~~In addition to the error fixed in #331, there was an additional error as well in `collaborators()`, which also it no longer properly detected 404 errors.~~

~~Reason for that second error is that npm has changed the human readable error it outputs and there's no json output for that command. I therefore added a new `checkExistance()` method which utilizes the same method that #331 introduced to check if the error that happens in `collaborators()` plausibly could be caused by the lack of an existing package.~~

Update: Second issue discussed in #339 and is a regression in npm `6.6.0`

After those two changes, included here as two atomic commits – one each, the publishing of my package succeeded.