### PR TITLE
Detect all tags in `latestTag()`

### DIFF
--- a/source/git-util.js
+++ b/source/git-util.js
@@ -1,7 +1,7 @@
 'use strict';
 const execa = require('execa');
 
-const latestTag = () => execa.stdout('git', ['describe', '--abbrev=0']);
+const latestTag = () => execa.stdout('git', ['describe', '--abbrev=0', '--tags']);
 
 const firstCommit = () => execa.stdout('git', ['rev-list', '--max-parents=0', 'HEAD']);
 


### PR DESCRIPTION
This makes `np` correctly print out the commit history in case no previous _annotated_ tags are found but previous _unannotated_ tags do exist. See more on this in #338.