### PR TITLE
feat: add standard version support

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"rxjs": "^6.3.3",
 		"semver": "^5.2.0",
 		"split": "^1.0.0",
+		"standard-version": "^4.4.0",
 		"symbol-observable": "^1.2.0",
 		"terminal-link": "^1.2.0",
 		"update-notifier": "^2.1.0"

--- a/source/cli.js
+++ b/source/cli.js
@@ -20,13 +20,15 @@ const cli = meow(`
 	    ${version.SEMVER_INCREMENTS.join(' | ')} | 1.2.3
 
 	Options
-	  --any-branch  Allow publishing from any branch
-	  --no-cleanup  Skips cleanup of node_modules
-	  --yolo        Skips cleanup and testing
-	  --no-publish  Skips publishing
-	  --tag         Publish under a given dist-tag
-	  --no-yarn     Don't use Yarn
-	  --contents    Subdirectory to publish
+	  --any-branch        Allow publishing from any branch
+	  --no-cleanup        Skips cleanup of node_modules
+	  --yolo              Skips cleanup and testing
+	  --no-publish        Skips publishing
+	  --tag               Publish under a given dist-tag
+	  --no-yarn           Don't use Yarn
+	  --contents          Subdirectory to publish
+	  --standard-version  Use standard-version
+	  --changelog-file    Changelog file to be updated by standard-version
 
 	Examples
 	  $ np
@@ -59,6 +61,12 @@ const cli = meow(`
 		},
 		contents: {
 			type: 'string'
+		},
+		standardVersion: {
+			type: 'boolean'
+		},
+		changelogFile: {
+			type: 'string'
 		}
 	}
 });
@@ -80,8 +88,10 @@ process.on('SIGINT', () => {
 			...cli.flags,
 			confirm: true,
 			version: cli.input[0]
-		} :
-		await ui({...cli.flags, exists: !isAvailable}, pkg);
+		} : cli.flags.standardVersion ? {
+			...cli.flags,
+			confirm: true
+		} : await ui({...cli.flags, exists: !isAvailable}, pkg);
 
 	if (!options.confirm) {
 		process.exit(0);


### PR DESCRIPTION
Updated version of PR #301.

This adds support for a `--standard-version` flag to use [conventional-changelog/standard-version](https://github.com/conventional-changelog/standard-version) for the versioning step.

`standard-version` is basically the same as `npm/yarn version`, plus, if following a conventional commits format, it figures out which version bump to use based on the commit messages, and updates the changelog along with the versioning commit.

I also added a `--changelog-file` CLI flag that allows to let `standard-version` know which input file to use (cause I like `changelog.md` rather than the default `CHANGELOG.md`).

Kind of closes #61.

Please let me know what you think? Could also add the changelog output into the Github release draft body? If you say this is out of scope, I'll maintain it as a fork for myself :nerd_face: