### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,25 +3,27 @@ name: Bug report
 about: Create a report to help us improve np
 ---
 
-<!--- Provide a general summary of the issue in the title above -->
+<!--- Provide a short summary of the issue in the title above -->
 
 ## Description
-<!-- Give a clear and concise description of what the bug is -->
 
-## Steps to Reproduce
-<!--- Tell us how we can reproduce the issue on our end -->
+<!-- Write a clear and concise description of what the issue is -->
+
+## Steps to reproduce
+
+<!--- Let us how how we can reproduce the issue on our end -->
 
 1.
 2.
 3.
-4.
 
-## Expected Behavior
+## Expected behavior
+
 <!--- Tell us what you expected to happen -->
 
 ## Environment
-<!-- Mention which versions of np, Node.js, npm and git you're using, -->
-<!-- as well as your OS and version-->
+
+<!-- Mention which versions of np, Node.js, npm and Git you're using, as well as your OS and version -->
 
 np - x.x.x
 Node.js - x.x.x

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,12 @@
+---
+name: Bug report
+about: Create a report to help us improve np
+---
+
 <!--- Provide a general summary of the issue in the title above -->
 
 ## Description
-<!-- Give a clear and concise description of what the bug is, -->
-<!-- or what new feature you'd like np to have. -->
+<!-- Give a clear and concise description of what the bug is -->
 
 ## Steps to Reproduce
 <!--- Tell us how we can reproduce the issue on our end -->
@@ -16,9 +20,11 @@
 <!--- Tell us what you expected to happen -->
 
 ## Environment
-<!-- Mention which versions of np, Node.js, npm and git you're using -->
+<!-- Mention which versions of np, Node.js, npm and git you're using, -->
+<!-- as well as your OS and version-->
 
 np - x.x.x
 Node.js - x.x.x
 npm - x.x.x
 Git - x.x.x
+OS - XXX x.x.x

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,17 +3,20 @@ name: Feature request
 about: Suggest an idea
 ---
 
-<!--- Provide a general summary of the request in the title above -->
+<!--- Provide a short summary of the request in the title above -->
 
 ## Description
-<!-- Give a clear and concise description of what new feature -->
-<!-- you'd like np to have -->
+
+<!-- Write a clear and concise description of the feature -->
 
 **Is the feature request related to a problem?**
-<!-- Describe what the problem is (e.g. I'm always frustrated when [...]) -->
 
-## Possible Solution
-<!-- Tell us how you think the feature should be implemented -->
+<!-- Describe what the problem is (e.g. I'm always frustrated when […]) -->
+
+## Possible solution
+
+<!-- If possible, let us know how you think the feature should be implemented -->
 
 ## Alternatives 
+
 <!-- Include any alternative solutions and features you've considered -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for np
+about: Suggest an idea
 ---
 
 <!--- Provide a general summary of the request in the title above -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for np
+---
+
+<!--- Provide a general summary of the request in the title above -->
+
+## Description
+<!-- Give a clear and concise description of what new feature -->
+<!-- you'd like np to have -->
+
+**Is the feature request related to a problem?**
+<!-- Describe what the problem is (e.g. I'm always frustrated when [...]) -->
+
+## Possible Solution
+<!-- Tell us how you think the feature should be implemented -->
+
+## Alternatives 
+<!-- Include any alternative solutions and features you've considered -->

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,24 @@
+<!--- Provide a general summary of the issue in the title above -->
+
+## Description
+<!-- Give a clear and concise description of what the bug is, -->
+<!-- or what new feature you'd like np to have. -->
+
+## Steps to Reproduce
+<!--- Tell us how we can reproduce the issue on our end -->
+
+1.
+2.
+3.
+4.
+
+## Expected Behavior
+<!--- Tell us what you expected to happen -->
+
+## Environment
+<!-- Mention which versions of np, Node.js, npm and git you're using -->
+
+np - x.x.x
+Node.js - x.x.x
+npm - x.x.x
+Git - x.x.x

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 
-Thanks for submitting a pull request 
+Thanks for submitting a pull request 🙌
 
 **Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+<!--
+
+IMPORTANT: Please do not create a pull request which adds new functionality or modifies existing one without creating an issue first.
+We are excited about pull requests, but please try to limit the scope and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.
+
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 
-IMPORTANT: Please do not create a pull request which adds new functionality or modifies existing one without creating an issue first.
+IMPORTANT: Please do not create a pull request which has major and significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.
 We are excited about pull requests, but please try to limit the scope and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.
 
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 <!--
 
-IMPORTANT: Please do not create a pull request which has major and significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.
-We are excited about pull requests, but please try to limit the scope and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.
+Thanks for submitting a pull request 
+
+**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.
+
+Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.
 
 -->


### PR DESCRIPTION
This adds a basic issue template, inspired by GitHub's default bug report template and [this template](https://raw.githubusercontent.com/stevemao/github-issue-templates/master/bugs-only/ISSUE_TEMPLATE.md).
Note that I added a single template for both bug reports and feature requests, but I could split it to two separate templates (this way, we'll also be able to take advantage of [GitHub's issue template feature](https://help.github.com/en/articles/creating-issue-templates-for-your-repository)).

Fixes #352.