### PR TITLE
Add `--no-release-draft` flag to skip opening a GitHub release draft page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ $ np --help
     --tag               Publish under a given dist-tag
     --no-yarn           Don't use Yarn
     --contents          Subdirectory to publish
-    --no-release-draft  Don't open a GitHub release draft
+    --no-release-draft  Skips opening a GitHub release draft
 
   Examples
     $ np

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ $ np --help
     --no-cleanup  Skips cleanup of node_modules
     --yolo        Skips cleanup and testing
     --no-publish  Skips publishing
-		--no-draft    Don't open a GitHub release draft
+    --no-draft    Don't open a GitHub release draft
     --tag         Publish under a given dist-tag
     --no-yarn     Don't use Yarn
     --contents    Subdirectory to publish

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ $ np --help
     --no-cleanup  Skips cleanup of node_modules
     --yolo        Skips cleanup and testing
     --no-publish  Skips publishing
+		--no-draft    Don't open a GitHub release draft
     --tag         Publish under a given dist-tag
     --no-yarn     Don't use Yarn
     --contents    Subdirectory to publish

--- a/readme.md
+++ b/readme.md
@@ -62,14 +62,14 @@ $ np --help
       patch | minor | major | prepatch | preminor | premajor | prerelease | 1.2.3
 
   Options
-    --any-branch  Allow publishing from any branch
-    --no-cleanup  Skips cleanup of node_modules
-    --yolo        Skips cleanup and testing
-    --no-publish  Skips publishing
-    --no-draft    Don't open a GitHub release draft
-    --tag         Publish under a given dist-tag
-    --no-yarn     Don't use Yarn
-    --contents    Subdirectory to publish
+    --any-branch        Allow publishing from any branch
+    --no-cleanup        Skips cleanup of node_modules
+    --yolo              Skips cleanup and testing
+    --no-publish        Skips publishing
+    --tag               Publish under a given dist-tag
+    --no-yarn           Don't use Yarn
+    --contents          Subdirectory to publish
+    --no-release-draft  Don't open a GitHub release draft
 
   Examples
     $ np

--- a/source/cli.js
+++ b/source/cli.js
@@ -23,8 +23,8 @@ const cli = meow(`
 	  --any-branch  Allow publishing from any branch
 	  --no-cleanup  Skips cleanup of node_modules
 	  --yolo        Skips cleanup and testing
-    --no-publish  Skips publishing
-    --no-draft    Don't open a GitHub release draft
+	  --no-publish  Skips publishing
+	  --no-draft    Don't open a GitHub release draft
 	  --tag         Publish under a given dist-tag
 	  --no-yarn     Don't use Yarn
 	  --contents    Subdirectory to publish

--- a/source/cli.js
+++ b/source/cli.js
@@ -27,7 +27,7 @@ const cli = meow(`
 	  --tag               Publish under a given dist-tag
 	  --no-yarn           Don't use Yarn
 	  --contents          Subdirectory to publish
-	  --no-release-draft  Don't open a GitHub release draft
+	  --no-release-draft  Skips opening a GitHub release draft
 
 	Examples
 	  $ np

--- a/source/cli.js
+++ b/source/cli.js
@@ -23,7 +23,8 @@ const cli = meow(`
 	  --any-branch  Allow publishing from any branch
 	  --no-cleanup  Skips cleanup of node_modules
 	  --yolo        Skips cleanup and testing
-	  --no-publish  Skips publishing
+    --no-publish  Skips publishing
+    --no-draft    Don't open a GitHub release draft
 	  --tag         Publish under a given dist-tag
 	  --no-yarn     Don't use Yarn
 	  --contents    Subdirectory to publish
@@ -47,6 +48,10 @@ const cli = meow(`
 			type: 'boolean'
 		},
 		publish: {
+			type: 'boolean',
+			default: true
+		},
+		draft: {
 			type: 'boolean',
 			default: true
 		},

--- a/source/cli.js
+++ b/source/cli.js
@@ -20,14 +20,14 @@ const cli = meow(`
 	    ${version.SEMVER_INCREMENTS.join(' | ')} | 1.2.3
 
 	Options
-	  --any-branch  Allow publishing from any branch
-	  --no-cleanup  Skips cleanup of node_modules
-	  --yolo        Skips cleanup and testing
-	  --no-publish  Skips publishing
-	  --no-draft    Don't open a GitHub release draft
-	  --tag         Publish under a given dist-tag
-	  --no-yarn     Don't use Yarn
-	  --contents    Subdirectory to publish
+	  --any-branch        Allow publishing from any branch
+	  --no-cleanup        Skips cleanup of node_modules
+	  --yolo              Skips cleanup and testing
+	  --no-publish        Skips publishing
+	  --tag               Publish under a given dist-tag
+	  --no-yarn           Don't use Yarn
+	  --contents          Subdirectory to publish
+	  --no-release-draft  Don't open a GitHub release draft
 
 	Examples
 	  $ np
@@ -51,7 +51,7 @@ const cli = meow(`
 			type: 'boolean',
 			default: true
 		},
-		draft: {
+		releaseDraft: {
 			type: 'boolean',
 			default: true
 		},

--- a/source/index.js
+++ b/source/index.js
@@ -172,11 +172,13 @@ module.exports = async (input = 'patch', options) => {
 		task: () => git.push()
 	});
 
-	tasks.add({
-		title: 'Creating release draft on GitHub',
-		enabled: () => isOnGitHub === true,
-		task: () => releaseTaskHelper(options)
-	});
+	if (options.draft) {
+		tasks.add({
+			title: 'Creating release draft on GitHub',
+			enabled: () => isOnGitHub === true,
+			task: () => releaseTaskHelper(options)
+		});
+	}
 
 	await tasks.run();
 

--- a/source/index.js
+++ b/source/index.js
@@ -172,13 +172,12 @@ module.exports = async (input = 'patch', options) => {
 		task: () => git.push()
 	});
 
-	if (options.releaseDraft) {
-		tasks.add({
-			title: 'Creating release draft on GitHub',
-			enabled: () => isOnGitHub === true,
-			task: () => releaseTaskHelper(options)
-		});
-	}
+	tasks.add({
+		title: 'Creating release draft on GitHub',
+		enabled: () => isOnGitHub === true,
+		skip: () => options.releaseDraft,
+		task: () => releaseTaskHelper(options)
+	});
 
 	await tasks.run();
 

--- a/source/index.js
+++ b/source/index.js
@@ -172,7 +172,7 @@ module.exports = async (input = 'patch', options) => {
 		task: () => git.push()
 	});
 
-	if (options.draft) {
+	if (options.releaseDraft) {
 		tasks.add({
 			title: 'Creating release draft on GitHub',
 			enabled: () => isOnGitHub === true,


### PR DESCRIPTION
Resolves #371 