### PR TITLE
Always use globally installed npm binary

### DIFF
--- a/source/npm/enable-2fa.js
+++ b/source/npm/enable-2fa.js
@@ -11,7 +11,7 @@ const enable2fa = (packageName, options) => {
 		args.push('--otp', options.otp);
 	}
 
-	return execa('npm', args);
+	return execa('npm', args, {preferLocal: false});
 };
 
 module.exports = (task, packageName, options) =>

--- a/source/npm/publish.js
+++ b/source/npm/publish.js
@@ -23,7 +23,7 @@ const pkgPublish = (pkgManager, options) => {
 		args.push('--access', 'public');
 	}
 
-	return execa(pkgManager, args);
+	return execa(pkgManager, args, {preferLocal: false});
 };
 
 module.exports = (context, pkgManager, task, options) =>

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -8,7 +8,7 @@ const {verifyRequirementSatisfied} = require('../version');
 exports.checkConnection = () => pTimeout(
 	(async () => {
 		try {
-			await execa('npm', ['ping']);
+			await execa('npm', ['ping'], {preferLocal: false});
 			return true;
 		} catch (_) {
 			throw new Error('Connection to npm registry failed');
@@ -54,7 +54,7 @@ exports.prereleaseTags = async packageName => {
 
 	let tags = [];
 	try {
-		const {stdout} = await execa('npm', ['view', '--json', packageName, 'dist-tags']);
+		const {stdout} = await execa('npm', ['view', '--json', packageName, 'dist-tags'], {preferLocal: false});
 		tags = Object.keys(JSON.parse(stdout))
 			.filter(tag => tag !== 'latest');
 	} catch (error) {

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -26,7 +26,7 @@ exports.username = async ({externalRegistry}) => {
 	}
 
 	try {
-		return await execa.stdout('npm', args);
+		return await execa.stdout('npm', args, {preferLocal: false});
 	} catch (error) {
 		throw new Error(/ENEEDAUTH/.test(error.stderr) ?
 			'You must be logged in. Use `npm login` and try again.' :
@@ -38,7 +38,7 @@ exports.collaborators = async packageName => {
 	ow(packageName, ow.string);
 
 	try {
-		return await execa.stdout('npm', ['access', 'ls-collaborators', packageName]);
+		return await execa.stdout('npm', ['access', 'ls-collaborators', packageName], {preferLocal: false});
 	} catch (error) {
 		// Ignore non-existing package error
 		if (error.stderr.includes('code E404')) {

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -81,7 +81,7 @@ exports.isPackageNameAvailable = async pkg => {
 
 exports.isExternalRegistry = pkg => typeof pkg.publishConfig === 'object' && typeof pkg.publishConfig.registry === 'string';
 
-exports.version = () => execa.stdout('npm', ['--version']);
+exports.version = () => execa.stdout('npm', ['--version'], {preferLocal: false});
 
 exports.verifyRecentNpmVersion = async () => {
 	const npmVersion = await exports.version();

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -24,7 +24,7 @@ module.exports = (input, pkg, options) => {
 			title: 'Check yarn version',
 			enabled: () => options.yarn === true,
 			task: async () => {
-				const yarnVersion = await execa.stdout('yarn', ['--version']);
+				const yarnVersion = await execa.stdout('yarn', ['--version'], {preferLocal: false});
 				version.verifyRequirementSatisfied('yarn', yarnVersion);
 			}
 		},

--- a/source/util.js
+++ b/source/util.js
@@ -53,10 +53,10 @@ exports.getTagVersionPrefix = pMemoize(async options => {
 
 	try {
 		if (options.yarn) {
-			return await execa.stdout('yarn', ['config', 'get', 'version-tag-prefix']);
+			return await execa.stdout('yarn', ['config', 'get', 'version-tag-prefix'], {preferLocal: false});
 		}
 
-		return await execa.stdout('npm', ['config', 'get', 'tag-version-prefix']);
+		return await execa.stdout('npm', ['config', 'get', 'tag-version-prefix'], {preferLocal: false});
 	} catch (_) {
 		return 'v';
 	}


### PR DESCRIPTION
I just had an issue because of 2 different npm binaries installed on my machine. One was up-to-date and the other was very old. I figured out that the `node@10` I've installed with brew has a "local" npm binary attached to it.

For `execa`, `preferLocal` is set to `true` by default hence it will try to load local binaries first.

I think it's - for `npm` at least - a better idea to always load the global binary instead of any local (outdated) ones.
