### PR TITLE
Warn if no files field in package.json or .npmignore file present

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@
 - Supports [two-factor authentication](https://docs.npmjs.com/getting-started/using-two-factor-authentication)
 - Enables two-factor authentication on new repositories
 - Opens a prefilled GitHub Releases draft after publish
+- Warns about the possibility of extraneous files being published
 
 
 ## Prerequisite

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -1,8 +1,12 @@
 'use strict';
+const fs = require('fs');
+const path = require('path');
 const execa = require('execa');
 const pTimeout = require('p-timeout');
 const ow = require('ow');
 const npmName = require('npm-name');
+const chalk = require('chalk');
+const pkgDir = require('pkg-dir');
 const {verifyRequirementSatisfied} = require('../version');
 
 exports.checkConnection = () => pTimeout(
@@ -86,4 +90,15 @@ exports.version = () => execa.stdout('npm', ['--version']);
 exports.verifyRecentNpmVersion = async () => {
 	const npmVersion = await exports.version();
 	verifyRequirementSatisfied('npm', npmVersion);
+};
+
+exports.checkIgnoreStrategy = ({files}) => {
+	const rootDir = pkgDir.sync();
+	const npmignoreExists = fs.existsSync(path.resolve(rootDir, '.npmignore'));
+
+	if (!files && !npmignoreExists) {
+		console.log(`
+		\n${chalk.bold.yellow('Warning:')} No ${chalk.bold.cyan('files')} field specified in ${chalk.bold.magenta('package.json')} nor is a ${chalk.bold.magenta('.npmignore')} file present. Having one of those will prevent you from accidentally publishing development-specific files along with your package's source code to npm. 
+		`);
+	}
 };

--- a/source/ui.js
+++ b/source/ui.js
@@ -5,7 +5,7 @@ const githubUrlFromGit = require('github-url-from-git');
 const isScoped = require('is-scoped');
 const util = require('./util');
 const git = require('./git-util');
-const {prereleaseTags} = require('./npm/util');
+const {prereleaseTags, checkIgnoreStrategy} = require('./npm/util');
 const version = require('./version');
 const prettyVersionDiff = require('./pretty-version-diff');
 
@@ -53,6 +53,8 @@ module.exports = async (options, pkg) => {
 	const oldVersion = pkg.version;
 	const extraBaseUrls = ['gitlab.com'];
 	const repoUrl = pkg.repository && githubUrlFromGit(pkg.repository.url, {extraBaseUrls});
+
+	checkIgnoreStrategy(pkg);
 
 	console.log(`\nPublish a new version of ${chalk.bold.magenta(pkg.name)} ${chalk.dim(`(current: ${oldVersion})`)}\n`);
 


### PR DESCRIPTION
I've read the discussion in #103 and I though: why not put a PR with some initial work up and see where it takes us?

I'm currently checking if the project has either a `files` field specified in the `package.json` or an `.npmignore` file in the root folder and just warning about it.

Thoughts?