### PR TITLE
Categorize commits and detect next version automatically

### DIFF
--- a/source/cli.js
+++ b/source/cli.js
@@ -32,7 +32,7 @@ const cli = meow(`
 	  --no-yarn           Don't use Yarn
 	  --contents          Subdirectory to publish
 	  --no-release-draft  Skips opening a GitHub release draft
-		--auto							Categorize changes and determine version automatically
+	  --auto              Categorize changes and determine version automatically
 
 	Examples
 	  $ np

--- a/source/detect-version.js
+++ b/source/detect-version.js
@@ -1,0 +1,130 @@
+'use strict';
+const inquirer = require('inquirer');
+const version = require('./version');
+const git = require('./git-util');
+const getCommits = require('./get-commits');
+const printCommitLog = require('./print-commit-log');
+
+const listCommits = commits => {
+	return commits.map(commit => `- ${commit.message}  ${commit.id}`);
+};
+
+const generateReleaseNotes = (commits, repoUrl, latest, nextTag) => {
+	const output = [];
+
+	const majorChanges = commits.filter(commit => commit.type === 'major');
+	const minorChanges = commits.filter(commit => commit.type === 'minor');
+	const patchChanges = commits.filter(commit => commit.type === 'patch');
+
+	if (majorChanges.length > 0) {
+		output.push('## Breaking changes', '', ...listCommits(majorChanges), '');
+	}
+
+	if (minorChanges.length > 0) {
+		output.push('## Features', '', ...listCommits(minorChanges), '');
+	}
+
+	if (patchChanges.length > 0) {
+		output.push('## Bug fixes', '', ...listCommits(patchChanges), '');
+	}
+
+	output.push('## All changes', '', `${repoUrl}/compare/${latest}...${nextTag}`);
+
+	return output.join('\n');
+};
+
+// Ask user about each commit and automatically determine the next release version
+module.exports = async (options, pkg) => {
+	const commits = await getCommits();
+
+	if (commits.length === 0) {
+		const answers = await inquirer.prompt([{
+			type: 'confirm',
+			name: 'confirm',
+			message: 'No commits found since previous release, continue?',
+			default: false
+		}]);
+
+		if (!answers.confirm) {
+			return {
+				...options,
+				...answers
+			};
+		}
+	}
+
+	await printCommitLog(commits, options.repoUrl);
+
+	const prompts = commits.map(commit => ({
+		type: 'list',
+		name: commit.id,
+		message: `What kind of change does "${commit.message}" commit contain?`,
+		choices: [
+			{
+				name: 'Bug fix',
+				value: 'patch'
+			},
+			{
+				name: 'Feature',
+				value: 'minor'
+			},
+			{
+				name: 'Breaking change',
+				value: 'major'
+			},
+			{
+				name: 'Docs',
+				value: 'docs'
+			},
+			{
+				name: 'Other',
+				value: 'other'
+			}
+		]
+	}));
+
+	const answers = await inquirer.prompt(prompts);
+
+	for (const [id, type] of Object.entries(answers)) {
+		const commit = commits.find(commit => commit.id === id);
+		commit.type = type;
+	}
+
+	const hasMajorChanges = commits.some(commit => commit.type === 'major');
+	const hasMinorChanges = commits.some(commit => commit.type === 'minor');
+	let bumpType = 'patch';
+
+	if (hasMinorChanges) {
+		bumpType = 'minor';
+	}
+
+	if (hasMajorChanges) {
+		bumpType = 'major';
+	}
+
+	const nextVersion = version(pkg.version).getNewVersionFrom(bumpType);
+
+	const {confirm} = await inquirer.prompt([{
+		type: 'confirm',
+		name: 'confirm',
+		message: `Determined next version to be ${nextVersion}, continue?`,
+		default: false
+	}]);
+
+	if (!confirm) {
+		return {
+			...options,
+			confirm
+		};
+	}
+
+	const latest = await git.latestTagOrFirstCommit();
+	const releaseNotes = nextTag => generateReleaseNotes(commits, options.repoUrl, latest, nextTag);
+
+	return {
+		...options,
+		confirm: true,
+		version: nextVersion,
+		releaseNotes
+	};
+};

--- a/source/get-commits.js
+++ b/source/get-commits.js
@@ -1,0 +1,20 @@
+'use strict';
+const git = require('./git-util');
+
+module.exports = async () => {
+	const latest = await git.latestTagOrFirstCommit();
+	const log = await git.commitLogFromRevision(latest);
+
+	if (!log) {
+		return [];
+	}
+
+	return log.split('\n')
+		.map(commit => {
+			const splitIndex = commit.lastIndexOf(' ');
+			return {
+				message: commit.slice(0, splitIndex),
+				id: commit.slice(splitIndex + 1)
+			};
+		});
+};

--- a/source/index.js
+++ b/source/index.js
@@ -59,7 +59,6 @@ module.exports = async (input = 'patch', options) => {
 	const rootDir = pkgDir.sync();
 	const hasLockFile = fs.existsSync(path.resolve(rootDir, options.yarn ? 'yarn.lock' : 'package-lock.json')) || fs.existsSync(path.resolve(rootDir, 'npm-shrinkwrap.json'));
 	const isOnGitHub = options.repoUrl && hostedGitInfo.fromUrl(options.repoUrl).type === 'github';
-
 	let isPublished = false;
 
 	const rollback = onetime(async () => {

--- a/source/print-commit-log.js
+++ b/source/print-commit-log.js
@@ -1,0 +1,18 @@
+'use strict';
+const chalk = require('chalk');
+const git = require('./git-util');
+const util = require('./util');
+
+module.exports = async (commits, repoUrl) => {
+	const latest = await git.latestTagOrFirstCommit();
+
+	const history = commits.map(commit => {
+		const commitMessage = util.linkifyIssues(repoUrl, commit.message);
+		const commitId = util.linkifyCommit(repoUrl, commit.id);
+		return `- ${commitMessage}  ${commitId}`;
+	}).join('\n');
+
+	const commitRange = util.linkifyCommitRange(repoUrl, `${latest}...master`);
+
+	console.log(`${chalk.bold('Commits:')}\n${history}\n\n${chalk.bold('Commit Range:')}\n${commitRange}\n`);
+};


### PR DESCRIPTION
This PR adds a new `--auto` flag, which lists all new commits and asks user about each of them whether it's a breaking change, a feature or a bug fix. Based on these answers, `np` figures out the next release version. For example, if at least one commit is a feature, `np` will create a minor release.

Check out a demo:

![ScreenFlow](https://user-images.githubusercontent.com/697676/58147105-dd41b200-7c0d-11e9-9d77-03f45243b41e.gif)

Default release bump is `patch`. Note that "Docs" and "Other" commits are treated the same way as bug fixes (patch) and ignored when generating release notes. 

After it's done, commits are also categorized by their type when generating a new release on GitHub - https://github.com/vadimdemedes/np-test/releases/tag/v3.0.0. I also updated default mode (without `--auto`) to generate release notes similar to the one above, except all commits are listed under `Highlights` section, like in [xo](https://github.com/xojs/xo/releases/tag/v0.24.0).

I also had to extract some common parts out of `source/ui.js`, like extracting list of commits and printing a commit log. Will leave more detailed comments in the diff.

Happy to change the `--auto` flag name as well!