### PR TITLE
Add missing closing bracket in `readme.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -216,7 +216,7 @@ If you use a Continuous Integration server to publish your tagged commits, use t
 
 ### Publish to gh-pages
 
-To publish to `gh-pages` or any other branch that serves your static assets), install [`branchsite`](https://github.com/enriquecaballero/branchsite), an `np`-like CLI tool aimed to complement `np`, and create an [npm "post" hook](https://docs.npmjs.com/misc/scripts) that runs after `np`.
+To publish to `gh-pages` (or any other branch that serves your static assets), install [`branchsite`](https://github.com/enriquecaballero/branchsite), an `np`-like CLI tool aimed to complement `np`, and create an [npm "post" hook](https://docs.npmjs.com/misc/scripts) that runs after `np`.
 
 ```
 $ npm install --save-dev branchsite


### PR DESCRIPTION
Fixes a tiny typo thing.