### PR TITLE
Exit if there are unpulled commits before interactive UI

### DIFF
--- a/source/ui.js
+++ b/source/ui.js
@@ -50,6 +50,8 @@ const printCommitLog = async repoUrl => {
 };
 
 module.exports = async (options, pkg) => {
+	await git.verifyRemoteHistoryIsClean();
+
 	const oldVersion = pkg.version;
 	const extraBaseUrls = ['gitlab.com'];
 	const repoUrl = pkg.repository && githubUrlFromGit(pkg.repository.url, {extraBaseUrls});


### PR DESCRIPTION
This PR adds the "Check remote history" task as a one time check before starting the interactive UI. 

Continuing without this check has the potential to show wrong information (version, commits - see #414) in the first interactive step, and later disappointment when the task is executed by `gitTasks` and execution is stopped then.

With this PR, `np` exits early. It looks like this:
```
E:\Projects\Cordova\cordova-plugin-splashscreen (master -> origin) (cordova-plugin-splashscreen@5.0.3)
λ np --no-publish

× Remote history differs. Please pull changes.
```

There don't seem to be any tests for `ui.js`, so I am unsure how to properly test this. (Was thinking about: Call `np` without options, "fake" `git.isRemoteHistoryClean` to return `false`, expect error `'Remote history differs. Please pull changes.'` to be thrown. Plus same for a clean history, and the error not being thrown and normal UI being started.)

closes #414