### PR TITLE
Add `tests` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ $ np --help
   Options
     --any-branch        Allow publishing from any branch
     --no-cleanup        Skips cleanup of node_modules
+    --no-tests          Skips tests
     --yolo              Skips cleanup and testing
     --no-publish        Skips publishing
     --tag               Publish under a given dist-tag
@@ -92,6 +93,7 @@ Currently, these are the flags you can configure:
 
 - `anyBranch` - Allow publishing from any branch (`false` by default).
 - `cleanup` - Cleanup `node_modules` (`true` by default).
+- `tests` - Run `npm test` (`true` by default).
 - `yolo` - Skip cleanup and testing (`false` by default).
 - `publish` - Publish (`true` by default).
 - `tag` - Publish under a given dist-tag (`latest` by default).

--- a/source/cli.js
+++ b/source/cli.js
@@ -23,6 +23,7 @@ const cli = meow(`
 	Options
 	  --any-branch        Allow publishing from any branch
 	  --no-cleanup        Skips cleanup of node_modules
+	  --no-tests          Skips tests
 	  --yolo              Skips cleanup and testing
 	  --no-publish        Skips publishing
 	  --tag               Publish under a given dist-tag
@@ -43,6 +44,9 @@ const cli = meow(`
 			type: 'boolean'
 		},
 		cleanup: {
+			type: 'boolean'
+		},
+		tests: {
 			type: 'boolean'
 		},
 		yolo: {
@@ -74,6 +78,7 @@ updateNotifier({pkg: cli.pkg}).notify();
 
 	const defaultFlags = {
 		cleanup: true,
+		tests: true,
 		publish: true,
 		yarn: hasYarn()
 	};

--- a/source/index.js
+++ b/source/index.js
@@ -37,6 +37,7 @@ const exec = (cmd, args) => {
 module.exports = async (input = 'patch', options) => {
 	options = {
 		cleanup: true,
+		tests: true,
 		publish: true,
 		...options
 	};
@@ -51,7 +52,7 @@ module.exports = async (input = 'patch', options) => {
 	}
 
 	const pkg = util.readPkg();
-	const runTests = !options.yolo;
+	const runTests = options.tests && !options.yolo;
 	const runCleanup = options.cleanup && !options.yolo;
 	const runPublish = options.publish && !pkg.private;
 	const pkgManager = options.yarn === true ? 'yarn' : 'npm';


### PR DESCRIPTION
I would like to be able to disable running `npm test` but keep cleanup enabled because I have a custom testing script inside `prepublishOnly`.

Similar to #299, I have tests running twice (possibly three times with git hooks as well).

Fixes #428