### PR TITLE
Avoid enabling 2FA for packages published to external registries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@
 - Rolls back the project to its previous state in case publishing fails
 - Pushes commits and tags (newly & previously created) to GitHub/GitLab
 - Supports [two-factor authentication](https://docs.npmjs.com/getting-started/using-two-factor-authentication)
-- Enables two-factor authentication on new repositories
+- Enables two-factor authentication on new repositories (does not apply to external registries)
 - Opens a prefilled GitHub Releases draft after publish
 
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,9 @@
 - Rolls back the project to its previous state in case publishing fails
 - Pushes commits and tags (newly & previously created) to GitHub/GitLab
 - Supports [two-factor authentication](https://docs.npmjs.com/getting-started/using-two-factor-authentication)
-- Enables two-factor authentication on new repositories (does not apply to external registries)
+- Enables two-factor authentication on new repositories
+  <br>
+  <sub>(does not apply to external registries)</sub>
 - Opens a prefilled GitHub Releases draft after publish
 
 

--- a/source/index.js
+++ b/source/index.js
@@ -197,7 +197,7 @@ module.exports = async (input = 'patch', options) => {
 		]);
 
 		const isExternalRegistry = npm.isExternalRegistry(pkg);
-		if (!options.exists && !(pkg.private || isExternalRegistry)) {
+		if (!options.exists && !pkg.private && !isExternalRegistry) {
 			tasks.add([
 				{
 					title: 'Enabling two-factor authentication',

--- a/source/index.js
+++ b/source/index.js
@@ -19,6 +19,7 @@ const prerequisiteTasks = require('./prerequisite-tasks');
 const gitTasks = require('./git-tasks');
 const publish = require('./npm/publish');
 const enable2fa = require('./npm/enable-2fa');
+const npm = require('./npm/util');
 const releaseTaskHelper = require('./release-task-helper');
 const util = require('./util');
 const git = require('./git-util');
@@ -195,7 +196,8 @@ module.exports = async (input = 'patch', options) => {
 			}
 		]);
 
-		if (!options.exists && !pkg.private) {
+		const isExternalRegistry = npm.isExternalRegistry(pkg);
+		if (!options.exists && !(pkg.private || isExternalRegistry)) {
 			tasks.add([
 				{
 					title: 'Enabling two-factor authentication',


### PR DESCRIPTION
External registry don't all support two-factor authentication.

For example, when using [Nexus as npm registry](https://blog.sonatype.com/using-nexus-3-as-your-repository-part-2-npm-packages), the command

```bash
> npm profile enable-2fa
```

fails with

```
npm ERR! code E400
npm ERR! 400 Bad Request - POST http://nexus.../content/groups/npm-all/-/npm/v1/tokens

npm ERR! A complete log of this run can be found in:
npm ERR!     ...npm/_logs/2019-06-20T09_24_05_833Z-debug.log
```

This change disables the two-factor authentication task for external registry so that we can continue to publish packages on Nexus.

<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
