### PR TITLE
Fix Yarn OTP failure

### DIFF
--- a/source/npm/handle-npm-error.js
+++ b/source/npm/handle-npm-error.js
@@ -9,7 +9,7 @@ const handleNpmError = (error, task, message, executor) => {
 		message = undefined;
 	}
 
-	if (error.stderr.includes('one-time pass') || error.message.includes('user TTY')) {
+	if (error.stderr.includes('one-time pass') || error.stdout.includes('Two factor authentication')) {
 		const {title} = task;
 		task.title = `${title} ${chalk.yellow('(waiting for input…)')}`;
 

--- a/source/npm/handle-npm-error.js
+++ b/source/npm/handle-npm-error.js
@@ -9,6 +9,7 @@ const handleNpmError = (error, task, message, executor) => {
 		message = undefined;
 	}
 
+	// `one-time pass` is for npm and `Two factor authentication` is for Yarn.
 	if (error.stderr.includes('one-time pass') || error.stdout.includes('Two factor authentication')) {
 		const {title} = task;
 		task.title = `${title} ${chalk.yellow('(waiting for input…)')}`;


### PR DESCRIPTION
The Yarn OTP feature broke after it was added in #302 because, for some reason, the [`error.message` string](https://github.com/sindresorhus/np/blob/1834e960f3256a34fe7b897e2ee1682745981545/source/npm/handle-npm-error.js#L12) no longer contains the error message. `error.stderr` does contain it though, so using `error.stderr.includes('user TTY')` would be one solution to fix this problem.

However, @sindresorhus [was asking about "any better parts of the output we could test"](https://github.com/sindresorhus/np/pull/302#discussion_r237354430) on the original PR. It turns out, Yarn does have this now — it logs the following message when 2FA is enabled:

```
info Two factor authentication enabled.
```

That's why I decided to use `error.stdout.includes('Two factor authentication')` instead.