### PR TITLE
Add `--branch` flag for specifying default branch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,7 @@ $ np --help
 
   Options
     --any-branch        Allow publishing from any branch
+    --branch            Branch name to set as default branch [Default: master]
     --no-cleanup        Skips cleanup of node_modules
     --no-tests          Skips tests
     --yolo              Skips cleanup and testing

--- a/source/cli.js
+++ b/source/cli.js
@@ -22,7 +22,7 @@ const cli = meow(`
 
 	Options
 	  --any-branch        Allow publishing from any branch
-	  --default-branch    Branch name to set as default branch (defaults to master)
+	  --branch            Branch name to set as default branch [Default: master]
 	  --no-cleanup        Skips cleanup of node_modules
 	  --no-tests          Skips tests
 	  --yolo              Skips cleanup and testing

--- a/source/cli.js
+++ b/source/cli.js
@@ -22,6 +22,7 @@ const cli = meow(`
 
 	Options
 	  --any-branch        Allow publishing from any branch
+	  --default-branch    Branch name to set as default branch (defaults to master)
 	  --no-cleanup        Skips cleanup of node_modules
 	  --no-tests          Skips tests
 	  --yolo              Skips cleanup and testing
@@ -42,6 +43,10 @@ const cli = meow(`
 	flags: {
 		anyBranch: {
 			type: 'boolean'
+		},
+		defaultBranch: {
+			type: 'string',
+			default: 'master'
 		},
 		cleanup: {
 			type: 'boolean'

--- a/source/git-tasks.js
+++ b/source/git-tasks.js
@@ -6,7 +6,7 @@ module.exports = options => {
 	const tasks = [
 		{
 			title: 'Check current branch',
-			task: () => git.verifyCurrentBranchIsMaster()
+			task: () => git.verifyCurrentBranchIsMaster(options.defaultBranch)
 		},
 		{
 			title: 'Check local working tree',

--- a/source/git-tasks.js
+++ b/source/git-tasks.js
@@ -6,7 +6,7 @@ module.exports = options => {
 	const tasks = [
 		{
 			title: 'Check current branch',
-			task: () => git.verifyCurrentBranchIsMaster(options.defaultBranch)
+			task: () => git.verifyCurrentBranchIsDefault(options.defaultBranch)
 		},
 		{
 			title: 'Check local working tree',

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -38,8 +38,8 @@ exports.currentBranch = async () => {
 	return stdout;
 };
 
-exports.verifyCurrentBranchIsDefault = async (targetBranch = 'master') => {
-	if (await exports.currentBranch() !== targetBranch) {
+exports.verifyCurrentBranchIsDefault = async (defaultBranch = 'master') => {
+	if (await exports.currentBranch() !== defaultBranch) {
 		throw new Error('Not on `master` branch. Use --any-branch to publish anyway.');
 	}
 };

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -38,7 +38,7 @@ exports.currentBranch = async () => {
 	return stdout;
 };
 
-exports.verifyCurrentBranchIsMaster = async (targetBranch = 'master') => {
+exports.verifyCurrentBranchIsDefault = async (targetBranch = 'master') => {
 	if (await exports.currentBranch() !== targetBranch) {
 		throw new Error('Not on `master` branch. Use --any-branch to publish anyway.');
 	}

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -38,8 +38,8 @@ exports.currentBranch = async () => {
 	return stdout;
 };
 
-exports.verifyCurrentBranchIsMaster = async () => {
-	if (await exports.currentBranch() !== 'master') {
+exports.verifyCurrentBranchIsMaster = async (targetBranch = 'master') => {
+	if (await exports.currentBranch() !== targetBranch) {
 		throw new Error('Not on `master` branch. Use --any-branch to publish anyway.');
 	}
 };

--- a/test/git-util.js
+++ b/test/git-util.js
@@ -20,8 +20,9 @@ test('verifyCurrentBranchIsDefault throws if current branch is not master', asyn
 });
 
 test('verifyCurrentBranchIsDefault doesn\'t throw if current branch the specified default branch', async t => {
-	currentBranchStub.returns('bestBranch');
-	await t.notThrowsAsync(gitUtil.verifyCurrentBranchIsDefault('bestBranch'));
+	const currentBranchName = 'bestBranch';
+	currentBranchStub.returns(currentBranchName);
+	await t.notThrowsAsync(gitUtil.verifyCurrentBranchIsDefault(currentBranchName));
 });
 
 test('verifyCurrentBranchIsDefault throws if current branch is not default branch', async t => {

--- a/test/git-util.js
+++ b/test/git-util.js
@@ -1,0 +1,30 @@
+import test from 'ava';
+import sinon from 'sinon';
+import gitUtil from '../source/git-util';
+
+const sandbox = sinon.createSandbox();
+const currentBranchStub = sinon.stub(gitUtil, 'currentBranch');
+
+test.afterEach(() => {
+	sandbox.restore();
+});
+
+test('verifyCurrentBranchIsMaster doesn\'t throw if current branch is master', async t => {
+	currentBranchStub.returns('master');
+	await t.notThrowsAsync(gitUtil.verifyCurrentBranchIsMaster);
+});
+
+test('verifyCurrentBranchIsMaster throws if current branch is not master', async t => {
+	currentBranchStub.returns('not master');
+	await t.throwsAsync(gitUtil.verifyCurrentBranchIsMaster);
+});
+
+test('verifyCurrentBranchIsMaster doesn\'t throw if current branch the specified default branch', async t => {
+	currentBranchStub.returns('bestBranch');
+	await t.notThrowsAsync(gitUtil.verifyCurrentBranchIsMaster('bestBranch'));
+});
+
+test('verifyCurrentBranchIsMaster throws if current branch is not default branch', async t => {
+	currentBranchStub.returns('unicorn-wrangler');
+	await t.throwsAsync(gitUtil.verifyCurrentBranchIsMaster('unicorn'));
+});

--- a/test/git-util.js
+++ b/test/git-util.js
@@ -9,22 +9,22 @@ test.afterEach(() => {
 	sandbox.restore();
 });
 
-test('verifyCurrentBranchIsMaster doesn\'t throw if current branch is master', async t => {
+test('verifyCurrentBranchIsDefault doesn\'t throw if current branch is master', async t => {
 	currentBranchStub.returns('master');
-	await t.notThrowsAsync(gitUtil.verifyCurrentBranchIsMaster);
+	await t.notThrowsAsync(gitUtil.verifyCurrentBranchIsDefault);
 });
 
-test('verifyCurrentBranchIsMaster throws if current branch is not master', async t => {
+test('verifyCurrentBranchIsDefault throws if current branch is not master', async t => {
 	currentBranchStub.returns('not master');
-	await t.throwsAsync(gitUtil.verifyCurrentBranchIsMaster);
+	await t.throwsAsync(gitUtil.verifyCurrentBranchIsDefault);
 });
 
-test('verifyCurrentBranchIsMaster doesn\'t throw if current branch the specified default branch', async t => {
+test('verifyCurrentBranchIsDefault doesn\'t throw if current branch the specified default branch', async t => {
 	currentBranchStub.returns('bestBranch');
-	await t.notThrowsAsync(gitUtil.verifyCurrentBranchIsMaster('bestBranch'));
+	await t.notThrowsAsync(gitUtil.verifyCurrentBranchIsDefault('bestBranch'));
 });
 
-test('verifyCurrentBranchIsMaster throws if current branch is not default branch', async t => {
+test('verifyCurrentBranchIsDefault throws if current branch is not default branch', async t => {
 	currentBranchStub.returns('unicorn-wrangler');
-	await t.throwsAsync(gitUtil.verifyCurrentBranchIsMaster('unicorn'));
+	await t.throwsAsync(gitUtil.verifyCurrentBranchIsDefault('unicorn'));
 });


### PR DESCRIPTION
Fixes: #466 

Tweaks the `verifyCurrentBranchIsMaster` function to allow users to pass in a custom default branch name and restrict publishing to that branch only.

Question:
Do we want to default `--any-branch` on if users set `--default-branch` or is there another reason they might set one without the other?
I'm not familiar with Ava - is there a way to group tests like a describe block to group these `verifyCurrentBranchIsDefault` tests?