### PR TITLE
Enforce matching engines on npm install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 - Ensures you are publishing from the `master` branch
 - Ensures the working directory is clean and that there are no unpulled changes
 - Reinstalls dependencies to ensure your project works with the latest dependency tree
-- Checks that your Node.js and npm versions are supported by the project and its dependencies
+- Ensures your Node.js and npm versions are supported by the project and its dependencies
 - Runs the tests
 - Bumps the version in package.json and npm-shrinkwrap.json (if present) and creates a git tag
 - Prevents [accidental publishing](https://github.com/npm/npm/issues/13248) of pre-release versions under the `latest` [dist-tag](https://docs.npmjs.com/cli/dist-tag)

--- a/readme.md
+++ b/readme.md
@@ -22,8 +22,8 @@
 - Ensures you are publishing from the `master` branch
 - Ensures the working directory is clean and that there are no unpulled changes
 - Reinstalls dependencies to ensure your project works with the latest dependency tree
+- Checks that your Node and npm versions are supported by the project and its dependencies
 - Runs the tests
-- Checks for Node version compatibility in all dependencies
 - Bumps the version in package.json and npm-shrinkwrap.json (if present) and creates a git tag
 - Prevents [accidental publishing](https://github.com/npm/npm/issues/13248) of pre-release versions under the `latest` [dist-tag](https://docs.npmjs.com/cli/dist-tag)
 - Publishes the new version to npm, optionally under a dist-tag

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@
 - Ensures the working directory is clean and that there are no unpulled changes
 - Reinstalls dependencies to ensure your project works with the latest dependency tree
 - Runs the tests
+- Checks for Node version compatibility in all dependencies
 - Bumps the version in package.json and npm-shrinkwrap.json (if present) and creates a git tag
 - Prevents [accidental publishing](https://github.com/npm/npm/issues/13248) of pre-release versions under the `latest` [dist-tag](https://docs.npmjs.com/cli/dist-tag)
 - Publishes the new version to npm, optionally under a dist-tag

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 - Ensures you are publishing from the `master` branch
 - Ensures the working directory is clean and that there are no unpulled changes
 - Reinstalls dependencies to ensure your project works with the latest dependency tree
-- Checks that your Node and npm versions are supported by the project and its dependencies
+- Checks that your Node.js and npm versions are supported by the project and its dependencies
 - Runs the tests
 - Bumps the version in package.json and npm-shrinkwrap.json (if present) and creates a git tag
 - Prevents [accidental publishing](https://github.com/npm/npm/issues/13248) of pre-release versions under the `latest` [dist-tag](https://docs.npmjs.com/cli/dist-tag)

--- a/source/index.js
+++ b/source/index.js
@@ -139,7 +139,7 @@ module.exports = async (input = 'patch', options) => {
 				title: 'Installing dependencies using npm',
 				enabled: () => options.yarn === false,
 				task: () => {
-					const args = hasLockFile ? ['ci'] : ['install', '--no-package-lock', '--no-production'];
+					const args = hasLockFile ? ['ci'] : ['install', '--no-package-lock', '--no-production', '--engine-strict'];
 					return exec('npm', args);
 				}
 			}

--- a/source/index.js
+++ b/source/index.js
@@ -139,8 +139,8 @@ module.exports = async (input = 'patch', options) => {
 				title: 'Installing dependencies using npm',
 				enabled: () => options.yarn === false,
 				task: () => {
-					const args = hasLockFile ? ['ci'] : ['install', '--no-package-lock', '--no-production', '--engine-strict'];
-					return exec('npm', args);
+					const args = hasLockFile ? ['ci'] : ['install', '--no-package-lock', '--no-production'];
+					return exec('npm', [...args, '--engine-strict']);
 				}
 			}
 		]);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

Fixes #480

This PR enables the [engine-strict](https://docs.npmjs.com/misc/config#engine-strict) configuration for `npm install` when np reinstalls the dependencies. This will raise an error if the project or its dependencies have an `engines.node` in package.json that are incompatible with the current environment.

A question: should this be applied to the `npm ci` case as well? I ran `npm ci --engine-strict` in a package whose `engines.node` was incompatible with the current Node version and it did not complain, whereas `npm install --engine-strict` did complain in the same situation. However, I did not test what happens when dependencies have mismatched engines. I also did not test using the npm config environment variable, only the command line flag. Perhaps an implementation quirk leads to `npm ci` loading configuration differently.