### PR TITLE
remove compare url from release notes

### DIFF
--- a/source/release-task-helper.js
+++ b/source/release-task-helper.js
@@ -11,7 +11,7 @@ module.exports = async (options, pkg) => {
 	const url = newGithubReleaseUrl({
 		repoUrl: options.repoUrl,
 		tag,
-		body: options.releaseNotes(tag),
+		body: options.releaseNotes(),
 		isPrerelease: version(options.version).isPrerelease()
 	});
 

--- a/source/ui.js
+++ b/source/ui.js
@@ -35,9 +35,8 @@ const printCommitLog = async repoUrl => {
 		return `- ${commitMessage}  ${commitId}`;
 	}).join('\n');
 
-	const releaseNotes = nextTag => commits.map(commit =>
-		`- ${commit.message}  ${commit.id}`
-	).join('\n') + `\n\n${repoUrl}/compare/${latest}...${nextTag}`;
+	const releaseNotes = () =>
+		commits.map(commit => `- ${commit.message}  ${commit.id}`).join('\n');
 
 	const commitRange = util.linkifyCommitRange(repoUrl, `${latest}...master`);
 


### PR DESCRIPTION
Hey hey!

Not sure if this is actually wanted but since [GitHub has shipped a release compare too](https://github.blog/changelog/2020-01-13-shortcut-to-compare-across-two-releases/), I think the compare link in the release notes is no longer needed?

