### PR TITLE
Fix checking collaborators when publishing to external registry

### DIFF
--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -39,11 +39,17 @@ exports.username = async ({externalRegistry}) => {
 	}
 };
 
-exports.collaborators = async packageName => {
+exports.collaborators = async pkg => {
+	const packageName = pkg.name;
 	ow(packageName, ow.string);
 
+	const args = ['access', 'ls-collaborators', packageName];
+	if (exports.isExternalRegistry(pkg)) {
+		args.push('--registry', pkg.publishConfig.registry);
+	}
+
 	try {
-		const {stdout} = await execa('npm', ['access', 'ls-collaborators', packageName]);
+		const {stdout} = await execa('npm', args);
 		return stdout;
 	} catch (error) {
 		// Ignore non-existing package error

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -36,7 +36,7 @@ module.exports = (input, pkg, options) => {
 					externalRegistry: isExternalRegistry ? pkg.publishConfig.registry : false
 				});
 
-				const collaborators = await npm.collaborators(pkg.name);
+				const collaborators = await npm.collaborators(pkg);
 				if (!collaborators) {
 					return;
 				}


### PR DESCRIPTION

I experienced issues when working with np and referencing an external registry. Although I added

```
"publishConfig": {
    "registry": "https://fooregistry.tld"
 },
```
to my package.json file and having an additional reference in the local .npmrc-file, the check prerequisities command required a long time and finally failed. As #339 states an npm update might help, but my version was already 6.13.1.

The reason for my issue was that the `npm.collaborators`-command missed an additional arg option "--registry https://fooregistry.tld": This PR adds the required option and thus fixes the `npm.collaborators`-command in order to allow collaborator checks for external registries.

Although these issues are already closed, the error I experienced with the most-current np version comes closest to those:

- Fixes #339 (is closed, but behaviour was the same due to another reason)
- Fixes #176 (is closed, but isn't clearly stated as fixed)