### PR TITLE
Escape HTML in release note commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"chalk": "^3.0.0",
 		"cosmiconfig": "^6.0.0",
 		"del": "^4.1.0",
+		"escape-goat": "^3.0.0",
 		"escape-string-regexp": "^2.0.0",
 		"execa": "^4.0.0",
 		"github-url-from-git": "^1.5.0",

--- a/source/ui.js
+++ b/source/ui.js
@@ -2,6 +2,7 @@
 const inquirer = require('inquirer');
 const chalk = require('chalk');
 const githubUrlFromGit = require('github-url-from-git');
+const {htmlEscape} = require('escape-goat');
 const isScoped = require('is-scoped');
 const util = require('./util');
 const git = require('./git-util');
@@ -36,7 +37,7 @@ const printCommitLog = async (repoUrl, registryUrl) => {
 	}).join('\n');
 
 	const releaseNotes = nextTag => commits.map(commit =>
-		`- ${commit.message}  ${commit.id}`
+		`- ${htmlEscape(commit.message)}  ${commit.id}`
 	).join('\n') + `\n\n${repoUrl}/compare/${latest}...${nextTag}`;
 
 	const commitRange = util.linkifyCommitRange(repoUrl, `${latest}...master`);


### PR DESCRIPTION
This PR escapes HTML special characters in commit messages included in the GitHub release notes body. This fixes #499.

I considered escaping the whole release body, but the relevant third-party stuff is only the commit messages, so I limited escaping to those. Maybe HTML will be needed in some future version of the generated release notes. Who knows. 🤷‍♂