### PR TITLE
Add pre-publish task tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,22 @@
 		"proxyquire": "^2.1.0",
 		"sinon": "^8.0.1",
 		"xo": "^0.25.3"
+	},
+        "xo": {
+		"rules": {
+			"ava/no-import-test-files": [
+				"off",
+				{
+					"files": [
+						"test/*"
+					]
+				}
+			]
+		}
+	},
+	"ava": {
+		"files": [
+			"!test/fixtures"
+		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
 	},
 	"devDependencies": {
 		"ava": "^2.3.0",
+		"execa_test_double": "^4.0.0",
+		"mockery": "^2.1.0",
 		"proxyquire": "^2.1.0",
 		"sinon": "^8.0.1",
 		"xo": "^0.25.3"

--- a/package.json
+++ b/package.json
@@ -73,18 +73,6 @@
 		"sinon": "^8.0.1",
 		"xo": "^0.25.3"
 	},
-        "xo": {
-		"rules": {
-			"ava/no-import-test-files": [
-				"off",
-				{
-					"files": [
-						"test/*"
-					]
-				}
-			]
-		}
-	},
 	"ava": {
 		"files": [
 			"!test/fixtures"

--- a/test/fixtures/listr-renderer.js
+++ b/test/fixtures/listr-renderer.js
@@ -1,20 +1,21 @@
+let tasks;
 
 class SilentRenderer {
 	constructor(_tasks) {
-		module.exports.tasks = _tasks;
+		tasks = _tasks;
+	}
+
+	static get tasks() {
+		return tasks;
 	}
 
 	static get nonTTY() {
 		return true;
 	}
 
-	render() {
-	}
+	render() { }
 
-	end() {
-
-	}
+	end() { }
 }
 
 module.exports.SilentRenderer = SilentRenderer;
-

--- a/test/fixtures/listr-renderer.js
+++ b/test/fixtures/listr-renderer.js
@@ -1,0 +1,20 @@
+
+class SilentRenderer {
+	constructor(_tasks) {
+		module.exports.tasks = _tasks;
+	}
+
+	static get nonTTY() {
+		return true;
+	}
+
+	render() {
+	}
+
+	end() {
+
+	}
+}
+
+module.exports.SilentRenderer = SilentRenderer;
+

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import execaStub from 'execa_test_double';
 import mockery from 'mockery';
-import {tasks, SilentRenderer} from './fixtures/listr-renderer';
+import {SilentRenderer} from './fixtures/listr-renderer';
 
 let testedModule;
 
@@ -34,7 +34,7 @@ test.serial('should fail when current branch not master and publishing from any 
 	]);
 	await t.throwsAsync(run(testedModule({})),
 		{message: 'Not on `master` branch. Use --any-branch to publish anyway.'});
-	t.true(tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
 });
 
 test.serial('should not fail when current branch not master and publishing from any branch permitted', async t => {
@@ -56,7 +56,7 @@ test.serial('should not fail when current branch not master and publishing from 
 		}
 	]);
 	await run(testedModule({anyBranch: true}));
-	t.false(tasks.some(task => task.title === 'Check current branch'));
+	t.false(SilentRenderer.tasks.some(task => task.title === 'Check current branch'));
 });
 
 test.serial('should fail when local working tree modified', async t => {
@@ -73,7 +73,7 @@ test.serial('should fail when local working tree modified', async t => {
 		}
 	]);
 	await t.throwsAsync(run(testedModule({})), {message: 'Unclean working tree. Commit or stash changes first.'});
-	t.true(tasks.some(task => task.title === 'Check local working tree' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check local working tree' && task.hasFailed()));
 });
 
 test.serial('should fail when remote history differs', async t => {
@@ -95,7 +95,7 @@ test.serial('should fail when remote history differs', async t => {
 		}
 	]);
 	await t.throwsAsync(run(testedModule({})), {message: 'Remote history differs. Please pull changes.'});
-	t.true(tasks.some(task => task.title === 'Check remote history' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check remote history' && task.hasFailed()));
 });
 
 test.serial('checks should pass when publishing from master, working tree is clean and remote history not different', async t => {
@@ -116,6 +116,5 @@ test.serial('checks should pass when publishing from master, working tree is cle
 			stdout: ''
 		}
 	]);
-	await run(testedModule({}));
-	t.pass();
+	await t.notThrowsAsync(run(testedModule({})));
 });

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -37,7 +37,7 @@ test.serial('should fail when current branch not master and publishing from any 
 	t.true(tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
 });
 
-test.serial('should not fail when current branch not master and publishing from any permitted', async t => {
+test.serial('should not fail when current branch not master and publishing from any branch permitted', async t => {
 	execaStub.createStub([
 		{
 			command: 'git symbolic-ref --short HEAD',

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -1,0 +1,121 @@
+import test from 'ava';
+import execaStub from 'execa_test_double';
+import mockery from 'mockery';
+import {tasks, SilentRenderer} from './fixtures/listr-renderer';
+
+let testedModule;
+
+const run = async listr => {
+	listr.setRenderer(SilentRenderer);
+	await listr.run();
+};
+
+test.before(() => {
+	mockery.registerMock('execa', execaStub.execa);
+	mockery.enable({
+		useCleanCache: true,
+		warnOnReplace: false,
+		warnOnUnregistered: false
+	});
+	testedModule = require('../source/git-tasks');
+});
+
+test.beforeEach(() => {
+	execaStub.resetStub();
+});
+
+test.serial('should fail when current branch not master and publishing from any branch not permitted', async t => {
+	execaStub.createStub([
+		{
+			command: 'git symbolic-ref --short HEAD',
+			exitCode: 0,
+			stdout: 'feature'
+		}
+	]);
+	await t.throwsAsync(run(testedModule({})),
+		{message: 'Not on `master` branch. Use --any-branch to publish anyway.'});
+	t.true(tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
+});
+
+test.serial('should not fail when current branch not master and publishing from any permitted', async t => {
+	execaStub.createStub([
+		{
+			command: 'git symbolic-ref --short HEAD',
+			exitCode: 0,
+			stdout: 'feature'
+		},
+		{
+			command: 'git status --porcelain',
+			exitCode: 0,
+			stdout: ''
+		},
+		{
+			command: 'git rev-list --count --left-only @{u}...HEAD',
+			exitCode: 0,
+			stdout: ''
+		}
+	]);
+	await run(testedModule({anyBranch: true}));
+	t.false(tasks.some(task => task.title === 'Check current branch'));
+});
+
+test.serial('should fail when local working tree modified', async t => {
+	execaStub.createStub([
+		{
+			command: 'git symbolic-ref --short HEAD',
+			exitCode: 0,
+			stdout: 'master'
+		},
+		{
+			command: 'git status --porcelain',
+			exitCode: 0,
+			stdout: 'M source/git-tasks.js'
+		}
+	]);
+	await t.throwsAsync(run(testedModule({})), {message: 'Unclean working tree. Commit or stash changes first.'});
+	t.true(tasks.some(task => task.title === 'Check local working tree' && task.hasFailed()));
+});
+
+test.serial('should fail when remote history differs', async t => {
+	execaStub.createStub([
+		{
+			command: 'git symbolic-ref --short HEAD',
+			exitCode: 0,
+			stdout: 'master'
+		},
+		{
+			command: 'git status --porcelain',
+			exitCode: 0,
+			stdout: ''
+		},
+		{
+			command: 'git rev-list --count --left-only @{u}...HEAD',
+			exitCode: 0,
+			stdout: '1'
+		}
+	]);
+	await t.throwsAsync(run(testedModule({})), {message: 'Remote history differs. Please pull changes.'});
+	t.true(tasks.some(task => task.title === 'Check remote history' && task.hasFailed()));
+});
+
+test.serial('checks should pass when publishing from master, working tree is clean and remote history not different', async t => {
+	execaStub.createStub([
+		{
+			command: 'git symbolic-ref --short HEAD',
+			exitCode: 0,
+			stdout: 'master'
+		},
+		{
+			command: 'git status --porcelain',
+			exitCode: 0,
+			stdout: ''
+		},
+		{
+			command: 'git rev-list --count --left-only @{u}...HEAD',
+			exitCode: 0,
+			stdout: ''
+		}
+	]);
+	await run(testedModule({}));
+	t.pass();
+});

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import execaStub from 'execa_test_double';
 import mockery from 'mockery';
 import version from '../source/version';
-import {tasks, SilentRenderer} from './fixtures/listr-renderer';
+import {SilentRenderer} from './fixtures/listr-renderer';
 
 let testedModule;
 
@@ -35,7 +35,7 @@ test.serial('public-package published on npm registry: should fail when npm regi
 	}]);
 	await t.throwsAsync(run(testedModule('1.0.0', {name: 'test'}, {})),
 		{message: 'Connection to npm registry failed'});
-	t.true(tasks.some(task => task.title === 'Ping npm registry' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && task.hasFailed()));
 });
 
 test.serial('private package: should skip task pinging npm registry', async t => {
@@ -47,7 +47,7 @@ test.serial('private package: should skip task pinging npm registry', async t =>
 		}
 	]);
 	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
-	t.true(tasks.some(task => task.title === 'Ping npm registry' && task.isSkipped()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && task.isSkipped()));
 });
 
 test.serial('external registry: should skip task pinging npm registry', async t => {
@@ -60,7 +60,7 @@ test.serial('external registry: should skip task pinging npm registry', async t 
 	]);
 	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', publishConfig: {registry: 'http://my.io'}},
 		{yarn: false}));
-	t.true(tasks.some(task => task.title === 'Ping npm registry' && task.isSkipped()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && task.isSkipped()));
 });
 
 test.serial('should fail when npm version does not match range in `package.json`', async t => {
@@ -79,7 +79,7 @@ test.serial('should fail when npm version does not match range in `package.json`
 	const depRange = require('../package.json').engines.npm;
 	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
 		{message: `Please upgrade to npm${depRange}`});
-	t.true(tasks.some(task => task.title === 'Check npm version' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check npm version' && task.hasFailed()));
 });
 
 test.serial('should fail when yarn version does not match range in `package.json`', async t => {
@@ -98,7 +98,7 @@ test.serial('should fail when yarn version does not match range in `package.json
 	const depRange = require('../package.json').engines.yarn;
 	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: true})),
 		{message: `Please upgrade to yarn${depRange}`});
-	t.true(tasks.some(task => task.title === 'Check yarn version' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check yarn version' && task.hasFailed()));
 });
 
 test.serial('should fail when user is not authenticated at npm registry', async t => {
@@ -118,7 +118,7 @@ test.serial('should fail when user is not authenticated at npm registry', async 
 	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
 		{message: 'You do not have write permissions required to publish this package.'});
 	process.env.NODE_ENV = 'test';
-	t.true(tasks.some(task => task.title === 'Verify user is authenticated' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Verify user is authenticated' && task.hasFailed()));
 });
 
 test.serial('should fail when user is not authenticated at external registry', async t => {
@@ -138,7 +138,7 @@ test.serial('should fail when user is not authenticated at external registry', a
 	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0', publishConfig: {registry: 'http://my.io'}}, {yarn: false})),
 		{message: 'You do not have write permissions required to publish this package.'});
 	process.env.NODE_ENV = 'test';
-	t.true(tasks.some(task => task.title === 'Verify user is authenticated' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Verify user is authenticated' && task.hasFailed()));
 });
 
 test.serial('private package: should skip task `verify user is authenticated`', async t => {
@@ -152,7 +152,7 @@ test.serial('private package: should skip task `verify user is authenticated`', 
 	process.env.NODE_ENV = 'P';
 	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
 	process.env.NODE_ENV = 'test';
-	t.true(tasks.some(task => task.title === 'Verify user is authenticated' && task.isSkipped()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Verify user is authenticated' && task.isSkipped()));
 });
 
 test.serial('should fail when git version does not match range in `package.json`', async t => {
@@ -166,7 +166,7 @@ test.serial('should fail when git version does not match range in `package.json`
 	const depRange = require('../package.json').engines.git;
 	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
 		{message: `Please upgrade to git${depRange}`});
-	t.true(tasks.some(task => task.title === 'Check git version' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check git version' && task.hasFailed()));
 });
 
 test.serial('should fail when git remote does not exists', async t => {
@@ -180,25 +180,25 @@ test.serial('should fail when git remote does not exists', async t => {
 	]);
 	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
 		{message: 'not found'});
-	t.true(tasks.some(task => task.title === 'Check git remote' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check git remote' && task.hasFailed()));
 });
 
 test.serial('should fail when version is invalid', async t => {
 	await t.throwsAsync(run(testedModule('DDD', {name: 'test', version: '1.0.0'}, {yarn: false})),
 		{message: `Version should be either ${version.SEMVER_INCREMENTS.join(', ')}, or a valid semver version.`});
-	t.true(tasks.some(task => task.title === 'Validate version' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Validate version' && task.hasFailed()));
 });
 
 test.serial('should fail when version is lower as latest version', async t => {
 	await t.throwsAsync(run(testedModule('0.1.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
 		{message: 'New version `0.1.0` should be higher than current version `1.0.0`'});
-	t.true(tasks.some(task => task.title === 'Validate version' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Validate version' && task.hasFailed()));
 });
 
 test.serial('should fail when prerelease version of public package without dist tag given', async t => {
 	await t.throwsAsync(run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0'}, {yarn: false})),
 		{message: 'You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag'});
-	t.true(tasks.some(task => task.title === 'Check for pre-release version' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check for pre-release version' && task.hasFailed()));
 });
 
 test.serial('should not fail when prerelease version of public package with dist tag given', async t => {
@@ -208,8 +208,7 @@ test.serial('should not fail when prerelease version of public package with dist
 			stdout: ''
 		}
 	]);
-	await run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0'}, {yarn: false, tag: 'pre'}));
-	t.pass();
+	await t.notThrowsAsync(run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0'}, {yarn: false, tag: 'pre'})));
 });
 
 test.serial('should not fail when prerelease version of private package without dist tag given', async t => {
@@ -219,8 +218,7 @@ test.serial('should not fail when prerelease version of private package without 
 			stdout: ''
 		}
 	]);
-	await run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
-	t.pass();
+	await t.notThrowsAsync(run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0', private: true}, {yarn: false})));
 });
 
 test.serial('should fail when git tag already exists', async t => {
@@ -232,7 +230,7 @@ test.serial('should fail when git tag already exists', async t => {
 	]);
 	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
 		{message: 'Git tag `v2.0.0` already exists.'});
-	t.true(tasks.some(task => task.title === 'Check git tag existence' && task.hasFailed()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check git tag existence' && task.hasFailed()));
 });
 
 test.serial('checks should pass', async t => {
@@ -242,6 +240,5 @@ test.serial('checks should pass', async t => {
 			stdout: ''
 		}
 	]);
-	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false}));
-	t.pass();
+	await t.notThrowsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})));
 });

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -1,0 +1,264 @@
+import test from 'ava';
+import execaStub from 'execa_test_double';
+import mockery from 'mockery';
+import version from '../source/version';
+
+let testedModule;
+let tasks;
+
+class SilentRenderer {
+	constructor(_tasks) {
+		tasks = _tasks;
+	}
+
+	static get nonTTY() {
+		return true;
+	}
+
+	render() {
+	}
+
+	end() {
+
+	}
+}
+
+const run = async listr => {
+	listr.setRenderer(SilentRenderer);
+	await listr.run();
+};
+
+test.before(() => {
+	mockery.registerMock('execa', execaStub.execa);
+	mockery.enable({
+		useCleanCache: true,
+		warnOnReplace: false,
+		warnOnUnregistered: false
+	});
+	testedModule = require('../source/prerequisite-tasks');
+});
+
+test.beforeEach(() => {
+	execaStub.resetStub();
+});
+
+test.serial('public-package published on npm registry: should fail when npm registry not pingable', async t => {
+	execaStub.createStub([{
+		command: 'npm ping',
+		exitCode: 1,
+		exitCodeName: 'EPERM',
+		stdout: '',
+		stderr: 'failed'
+	}]);
+	await t.throwsAsync(run(testedModule('1.0.0', {name: 'test'}, {})),
+		{message: 'Connection to npm registry failed'});
+	t.true(tasks.some(task => task.title === 'Ping npm registry' && task.hasFailed()));
+});
+
+test.serial('private package: should skip task pinging npm registry', async t => {
+	execaStub.createStub([
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			exitCode: 0,
+			stdout: ''
+		}
+	]);
+	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
+	t.true(tasks.some(task => task.title === 'Ping npm registry' && task.isSkipped()));
+});
+
+test.serial('external registry: should skip task pinging npm registry', async t => {
+	execaStub.createStub([
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			exitCode: 0,
+			stdout: ''
+		}
+	]);
+	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', publishConfig: {registry: 'http://my.io'}},
+		{yarn: false}));
+	t.true(tasks.some(task => task.title === 'Ping npm registry' && task.isSkipped()));
+});
+
+test.serial('should fail when npm version does not match range in `package.json`', async t => {
+	execaStub.createStub([
+		{
+			command: 'npm --version',
+			exitCode: 0,
+			stdout: '6.0.0'
+		},
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			exitCode: 0,
+			stdout: ''
+		}
+	]);
+	const depRange = require('../package.json').engines.npm;
+	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
+		{message: `Please upgrade to npm${depRange}`});
+	t.true(tasks.some(task => task.title === 'Check npm version' && task.hasFailed()));
+});
+
+test.serial('should fail when yarn version does not match range in `package.json`', async t => {
+	execaStub.createStub([
+		{
+			command: 'yarn --version',
+			exitCode: 0,
+			stdout: '1.0.0'
+		},
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			exitCode: 0,
+			stdout: ''
+		}
+	]);
+	const depRange = require('../package.json').engines.yarn;
+	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: true})),
+		{message: `Please upgrade to yarn${depRange}`});
+	t.true(tasks.some(task => task.title === 'Check yarn version' && task.hasFailed()));
+});
+
+test.serial('should fail when user is not authenticated at npm registry', async t => {
+	execaStub.createStub([
+		{
+			command: 'npm whoami',
+			exitCode: 0,
+			stdout: 'sindresorhus'
+		},
+		{
+			command: 'npm access ls-collaborators test',
+			exitCode: 0,
+			stdout: '{"sindresorhus": "read"}'
+		}
+	]);
+	process.env.NODE_ENV = 'P';
+	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
+		{message: 'You do not have write permissions required to publish this package.'});
+	process.env.NODE_ENV = 'test';
+	t.true(tasks.some(task => task.title === 'Verify user is authenticated' && task.hasFailed()));
+});
+
+test.serial('should fail when user is not authenticated at external registry', async t => {
+	execaStub.createStub([
+		{
+			command: 'npm whoami --registry http://my.io',
+			exitCode: 0,
+			stdout: 'sindresorhus'
+		},
+		{
+			command: 'npm access ls-collaborators test --registry http://my.io',
+			exitCode: 0,
+			stdout: '{"sindresorhus": "read"}'
+		}
+	]);
+	process.env.NODE_ENV = 'P';
+	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0', publishConfig: {registry: 'http://my.io'}}, {yarn: false})),
+		{message: 'You do not have write permissions required to publish this package.'});
+	process.env.NODE_ENV = 'test';
+	t.true(tasks.some(task => task.title === 'Verify user is authenticated' && task.hasFailed()));
+});
+
+test.serial('private package: should skip task `verify user is authenticated`', async t => {
+	execaStub.createStub([
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			exitCode: 0,
+			stdout: ''
+		}
+	]);
+	process.env.NODE_ENV = 'P';
+	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
+	process.env.NODE_ENV = 'test';
+	t.true(tasks.some(task => task.title === 'Verify user is authenticated' && task.isSkipped()));
+});
+
+test.serial('should fail when git version does not match range in `package.json`', async t => {
+	execaStub.createStub([
+		{
+			command: 'git version',
+			exitCode: 0,
+			stdout: 'git version 1.0.0'
+		}
+	]);
+	const depRange = require('../package.json').engines.git;
+	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
+		{message: `Please upgrade to git${depRange}`});
+	t.true(tasks.some(task => task.title === 'Check git version' && task.hasFailed()));
+});
+
+test.serial('should fail when git remote does not exists', async t => {
+	execaStub.createStub([
+		{
+			command: 'git ls-remote origin HEAD',
+			exitCode: 1,
+			exitCodeName: 'EPERM',
+			stderr: 'not found'
+		}
+	]);
+	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
+		{message: 'not found'});
+	t.true(tasks.some(task => task.title === 'Check git remote' && task.hasFailed()));
+});
+
+test.serial('should fail when version is invalid', async t => {
+	await t.throwsAsync(run(testedModule('DDD', {name: 'test', version: '1.0.0'}, {yarn: false})),
+		{message: `Version should be either ${version.SEMVER_INCREMENTS.join(', ')}, or a valid semver version.`});
+	t.true(tasks.some(task => task.title === 'Validate version' && task.hasFailed()));
+});
+
+test.serial('should fail when version is lower as latest version', async t => {
+	await t.throwsAsync(run(testedModule('0.1.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
+		{message: 'New version `0.1.0` should be higher than current version `1.0.0`'});
+	t.true(tasks.some(task => task.title === 'Validate version' && task.hasFailed()));
+});
+
+test.serial('should fail when prerelease version of public package without dist tag given', async t => {
+	await t.throwsAsync(run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0'}, {yarn: false})),
+		{message: 'You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag'});
+	t.true(tasks.some(task => task.title === 'Check for pre-release version' && task.hasFailed()));
+});
+
+test.serial('should not fail when prerelease version of public package with dist tag given', async t => {
+	execaStub.createStub([
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			stdout: ''
+		}
+	]);
+	await run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0'}, {yarn: false, tag: 'pre'}));
+	t.pass();
+});
+
+test.serial('should not fail when prerelease version of private package with dist tag given', async t => {
+	execaStub.createStub([
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			stdout: ''
+		}
+	]);
+	await run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
+	t.pass();
+});
+
+test.serial('should fail when git tag already exists', async t => {
+	execaStub.createStub([
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			stdout: 'vvb'
+		}
+	]);
+	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
+		{message: 'Git tag `v2.0.0` already exists.'});
+	t.true(tasks.some(task => task.title === 'Check git tag existence' && task.hasFailed()));
+});
+
+test.serial('no failures should be found', async t => {
+	execaStub.createStub([
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			stdout: ''
+		}
+	]);
+	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false}));
+	t.pass();
+});

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -2,26 +2,9 @@ import test from 'ava';
 import execaStub from 'execa_test_double';
 import mockery from 'mockery';
 import version from '../source/version';
+import {tasks, SilentRenderer} from './fixtures/listr-renderer';
 
 let testedModule;
-let tasks;
-
-class SilentRenderer {
-	constructor(_tasks) {
-		tasks = _tasks;
-	}
-
-	static get nonTTY() {
-		return true;
-	}
-
-	render() {
-	}
-
-	end() {
-
-	}
-}
 
 const run = async listr => {
 	listr.setRenderer(SilentRenderer);
@@ -252,7 +235,7 @@ test.serial('should fail when git tag already exists', async t => {
 	t.true(tasks.some(task => task.title === 'Check git tag existence' && task.hasFailed()));
 });
 
-test.serial('no failures should be found', async t => {
+test.serial('checks should pass', async t => {
 	execaStub.createStub([
 		{
 			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -212,7 +212,7 @@ test.serial('should not fail when prerelease version of public package with dist
 	t.pass();
 });
 
-test.serial('should not fail when prerelease version of private package with dist tag given', async t => {
+test.serial('should not fail when prerelease version of private package without dist tag given', async t => {
 	execaStub.createStub([
 		{
 			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',


### PR DESCRIPTION
Fixes #384. Stubs were created for the commands as mention in my [comment](https://github.com/sindresorhus/np/issues/384#issuecomment-589947855).
The tests run serially because the stubbed `execa`-dependency is cached when loaded the first time (see https://github.com/avajs/ava/issues/1066 and https://nodejs.org/api/modules.html#modules_caching).


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#384: Add tests for pre-publish tasks](https://issuehunt.io/repos/40806530/issues/384)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->