### PR TITLE
Correctly detect if np isn't run in a package

### DIFF
--- a/source/util.js
+++ b/source/util.js
@@ -9,9 +9,9 @@ const pkgDir = require('pkg-dir');
 
 exports.readPkg = (packagePath = pkgDir.sync()) => {
 	if (!packagePath) {
-		throw new Error(`No \`package.json\` found. Make sure the current directory is a valid package.`);
+		throw new Error('No `package.json` found. Make sure the current directory is a valid package.');
 	}
-	
+
 	const {packageJson} = readPkgUp.sync({
 		cwd: packagePath
 	});

--- a/source/util.js
+++ b/source/util.js
@@ -8,13 +8,13 @@ const ow = require('ow');
 const pkgDir = require('pkg-dir');
 
 exports.readPkg = (packagePath = pkgDir.sync()) => {
+	if (!packagePath) {
+		throw new Error(`No \`package.json\` found. Make sure the current directory is a valid package.`);
+	}
+	
 	const {packageJson} = readPkgUp.sync({
 		cwd: packagePath
 	});
-
-	if (!packageJson) {
-		throw new Error(`No package.json found. Make sure ${packagePath} is a valid package`);
-	}
 
 	return packageJson;
 };

--- a/source/util.js
+++ b/source/util.js
@@ -7,7 +7,9 @@ const pMemoize = require('p-memoize');
 const ow = require('ow');
 const pkgDir = require('pkg-dir');
 
-exports.readPkg = (packagePath = pkgDir.sync()) => {
+exports.readPkg = packagePath => {
+	packagePath = packagePath ? pkgDir.sync(packagePath) : pkgDir.sync();
+
 	if (!packagePath) {
 		throw new Error('No `package.json` found. Make sure the current directory is a valid package.');
 	}


### PR DESCRIPTION
The issue is that if you run np in a directory that isn't a package, `read-pkg-up` will throw an error.

// cc @lukeggchapman