### PR TITLE
Fully disable task with `--no-release-draft`

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -251,18 +251,18 @@ module.exports = async (input = 'patch', options) => {
 		task: () => git.push()
 	});
 
-	tasks.add({
-		title: 'Creating release draft on GitHub',
-		enabled: () => isOnGitHub === true,
-		skip: () => {
-			if (options.preview) {
-				return '[Preview] GitHub Releases draft will not be opened in preview mode.';
-			}
-
-			return !options.releaseDraft;
-		},
-		task: () => releaseTaskHelper(options, pkg)
-	});
+	if (options.releaseDraft) {
+		tasks.add({
+			title: 'Creating release draft on GitHub',
+			enabled: () => isOnGitHub === true,
+			skip: () => {
+				if (options.preview) {
+					return '[Preview] GitHub Releases draft will not be opened in preview mode.';
+				}
+			},
+			task: () => releaseTaskHelper(options, pkg)
+		});
+	}
 
 	await tasks.run();
 


### PR DESCRIPTION
When running with `--no-release-draft`, fully disable the task instead of just skipping it, thereby completely hiding it from the task list. Similar options behave the same way.

For example, the “Cleanup” task is hidden when running with `--no-cleanup`:

```console
$ np major

Publish a new version of foo (current: 1.0.0)


  ✔ Git
  ✔ Cleanup
  ✔ Installing dependencies using npm
  ✔ Running tests using npm
  ✔ Bumping version using npm
  ✔ Pushing tags
  ✔ Creating release draft on GitHub

 foo 2.0.0 published 🎉
$ np major --no-cleanup

Publish a new version of foo (current: 2.0.0)


  ✔ Git
  ✔ Running tests using npm
  ✔ Bumping version using npm
  ✔ Pushing tags
  ✔ Creating release draft on GitHub

 foo 3.0.0 published 🎉
```

However, the “Creating release draft on GitHub” task is listed as being skipped when running with `--no-release-draft`:

```console
$ np major --no-release-draft

Publish a new version of foo (current: 3.0.0)


  ✔ Git
  ✔ Cleanup
  ✔ Installing dependencies using npm
  ✔ Running tests using npm
  ✔ Bumping version using npm
  ✔ Pushing tags
  ↓ Creating release draft on GitHub [skipped]

 foo 4.0.0 published 🎉
```