### PR TITLE
Add `--no-2fa` flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ $ np --help
     --no-yarn           Don't use Yarn
     --contents          Subdirectory to publish
     --no-release-draft  Skips opening a GitHub release draft
+    --no-2fa            Don't enable 2FA on new packages
 
   Examples
     $ np

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@ Currently, these are the flags you can configure:
 - `yarn` - Use yarn if possible (`true` by default).
 - `contents` - Subdirectory to publish (`.` by default).
 - `releaseDraft` - Open a GitHub release draft after releasing (`true` by default).
+- `2Fa` - Enable 2FA on new packages (`true` by default)
 
 For example, this configures `np` to never use Yarn and to use `dist` as the subdirectory to publish:
 

--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ $ np --help
     --no-yarn           Don't use Yarn
     --contents          Subdirectory to publish
     --no-release-draft  Skips opening a GitHub release draft
-    --no-2fa            Don't enable 2FA on new packages
+    --no-2fa            Don't enable 2FA on new packages (not recommended)
 
   Examples
     $ np

--- a/source/cli.js
+++ b/source/cli.js
@@ -73,8 +73,7 @@ const cli = meow(`
 			type: 'boolean'
 		},
 		'2fa': {
-			type: 'boolean',
-			default: true
+			type: 'boolean'
 		}
 	}
 });
@@ -89,7 +88,8 @@ updateNotifier({pkg: cli.pkg}).notify();
 		tests: true,
 		publish: true,
 		releaseDraft: true,
-		yarn: hasYarn()
+		yarn: hasYarn(),
+		'2Fa': true
 	};
 
 	const localConfig = await config();

--- a/source/cli.js
+++ b/source/cli.js
@@ -31,6 +31,7 @@ const cli = meow(`
 	  --no-yarn           Don't use Yarn
 	  --contents          Subdirectory to publish
 	  --no-release-draft  Skips opening a GitHub release draft
+	  --no-2fa            Don't enable 2FA on new packages
 
 	Examples
 	  $ np
@@ -70,6 +71,10 @@ const cli = meow(`
 		},
 		preview: {
 			type: 'boolean'
+		},
+		'2fa': {
+			type: 'boolean',
+			default: true
 		}
 	}
 });

--- a/source/index.js
+++ b/source/index.js
@@ -215,7 +215,7 @@ module.exports = async (input = 'patch', options) => {
 		]);
 
 		const isExternalRegistry = npm.isExternalRegistry(pkg);
-		if (options.availability.isAvailable && !options.availability.isUnknown && !pkg.private && !isExternalRegistry) {
+		if (options['2Fa'] && options.availability.isAvailable && !options.availability.isUnknown && !pkg.private && !isExternalRegistry) {
 			tasks.add([
 				{
 					title: 'Enabling two-factor authentication',


### PR DESCRIPTION
Hello,

This adds a `--no-2fa` CLI option (as discussed in https://github.com/sindresorhus/np/issues/398) to bypass enabling 2FA on new packages.

The check is pretty trivial; if the `2Fa` option is set to false, the task is skipped. Default value is `true`.

The weird capitalization is because that's how CLI options starting with a number are converted internally.

I wanted to add tests to the feature but could not find similar tests I could use as a basis to write my own. Happy to add tests in exchange with a few pointers on how to get started.

Fixes #398