### PR TITLE
Fix `releaseDraft` setting not working when set from config not CLI

### DIFF
--- a/source/cli.js
+++ b/source/cli.js
@@ -57,8 +57,7 @@ const cli = meow(`
 			type: 'boolean'
 		},
 		releaseDraft: {
-			type: 'boolean',
-			default: true
+			type: 'boolean'
 		},
 		tag: {
 			type: 'string'
@@ -84,6 +83,7 @@ updateNotifier({pkg: cli.pkg}).notify();
 		cleanup: true,
 		tests: true,
 		publish: true,
+		releaseDraft: true,
 		yarn: hasYarn()
 	};
 


### PR DESCRIPTION
As mentioned in #515 by @pixelastic, the **releaseDraft** option is always overwritten by the default value of the CLI flags. Changing it within the package.json or .np-config is not possible.

