### PR TITLE
Update npm-name dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"log-symbols": "^3.0.0",
 		"meow": "^6.0.0",
 		"new-github-release-url": "^1.0.0",
-		"npm-name": "^5.4.0",
+		"npm-name": "^6.0.0",
 		"onetime": "^5.1.0",
 		"open": "^7.0.0",
 		"ow": "^0.15.0",


### PR DESCRIPTION

@sindresorhus it appears I am just following you around from is-url-superb to npm-name to np, but that's just because I'm using np as it really is a better npm publish

This continues the work of shedding the dependency with a security issue by allowing the use of your just-published npm-name version

Cheers :-)