### PR TITLE
Regression fix for tag not being taken when specified in CLI

### DIFF
--- a/source/ui.js
+++ b/source/ui.js
@@ -193,7 +193,7 @@ module.exports = async (options, pkg) => {
 
 	return {
 		...options,
-		version: answers.version || answers.customVersion || options.version ,
+		version: answers.version || answers.customVersion || options.version,
 		tag: answers.tag || answers.customTag || options.tag,
 		confirm: true,
 		repoUrl,

--- a/source/ui.js
+++ b/source/ui.js
@@ -193,8 +193,8 @@ module.exports = async (options, pkg) => {
 
 	return {
 		...options,
-		version: answers.version || answers.customVersion,
-		tag: answers.tag || answers.customTag,
+		version: answers.version || answers.customVersion || options.version ,
+		tag: answers.tag || answers.customTag || options.tag,
 		confirm: true,
 		repoUrl,
 		releaseNotes


### PR DESCRIPTION
Fixes #554 . Caused by always expecting ui to supply tag and not expecting it from cli.