### PR TITLE
Add support for `--no-2fa` flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ Currently, these are the flags you can configure:
 - `yarn` - Use yarn if possible (`true` by default).
 - `contents` - Subdirectory to publish (`.` by default).
 - `releaseDraft` - Open a GitHub release draft after releasing (`true` by default).
-- `2fa` - Enable 2FA on new packages (`true` by default) (not recommended).
+- `2fa` - Enable 2FA on new packages (`true` by default) (it's not recommended to set this to `false`).
 
 For example, this configures `np` to never use Yarn and to use `dist` as the subdirectory to publish:
 

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ $ np --help
     --no-yarn           Don't use Yarn
     --contents          Subdirectory to publish
     --no-release-draft  Skips opening a GitHub release draft
+    --no-2fa            Don't enable 2FA on new packages (not recommended)
 
   Examples
     $ np
@@ -93,6 +94,7 @@ Currently, these are the flags you can configure:
 - `yarn` - Use yarn if possible (`true` by default).
 - `contents` - Subdirectory to publish (`.` by default).
 - `releaseDraft` - Open a GitHub release draft after releasing (`true` by default).
+- `2fa` - Enable 2FA on new packages (`true` by default) (not recommended).
 
 For example, this configures `np` to never use Yarn and to use `dist` as the subdirectory to publish:
 

--- a/source/cli.js
+++ b/source/cli.js
@@ -104,6 +104,7 @@ updateNotifier({pkg: cli.pkg}).notify();
 		...cli.flags
 	};
 
+	// Workaround for unintended auto-casing behavior from `meow`.
 	if ('2Fa' in flags) {
 		flags['2fa'] = flags['2Fa'];
 	}

--- a/source/cli.js
+++ b/source/cli.js
@@ -32,6 +32,7 @@ const cli = meow(`
 	  --no-yarn           Don't use Yarn
 	  --contents          Subdirectory to publish
 	  --no-release-draft  Skips opening a GitHub release draft
+	  --no-2fa            Don't enable 2FA on new packages (not recommended)
 
 	Examples
 	  $ np
@@ -74,6 +75,9 @@ const cli = meow(`
 		},
 		preview: {
 			type: 'boolean'
+		},
+		'2fa': {
+			type: 'boolean'
 		}
 	}
 });
@@ -88,7 +92,8 @@ updateNotifier({pkg: cli.pkg}).notify();
 		tests: true,
 		publish: true,
 		releaseDraft: true,
-		yarn: hasYarn()
+		yarn: hasYarn(),
+		'2fa': true
 	};
 
 	const localConfig = await config();
@@ -98,6 +103,10 @@ updateNotifier({pkg: cli.pkg}).notify();
 		...localConfig,
 		...cli.flags
 	};
+
+	if ('2Fa' in flags) {
+		flags['2fa'] = flags['2Fa'];
+	}
 
 	const runPublish = flags.publish && !pkg.private;
 

--- a/source/index.js
+++ b/source/index.js
@@ -215,7 +215,7 @@ module.exports = async (input = 'patch', options) => {
 		]);
 
 		const isExternalRegistry = npm.isExternalRegistry(pkg);
-		if (options.availability.isAvailable && !options.availability.isUnknown && !pkg.private && !isExternalRegistry) {
+		if (options['2fa'] && options.availability.isAvailable && !options.availability.isUnknown && !pkg.private && !isExternalRegistry) {
 			tasks.add([
 				{
 					title: 'Enabling two-factor authentication',

--- a/test/index.js
+++ b/test/index.js
@@ -61,3 +61,31 @@ test('skip enabling 2FA if the package exists', async t => {
 
 	t.true(enable2faStub.notCalled);
 });
+
+test('skip enabling 2FA if the "2fa" option is false', async t => {
+	const enable2faStub = sinon.stub();
+
+	const np = proxyquire('../source', {
+		del: sinon.stub(),
+		execa: sinon.stub().returns({pipe: sinon.stub()}),
+		'./prerequisite-tasks': sinon.stub(),
+		'./git-tasks': sinon.stub(),
+		'./git-util': {
+			hasUpstream: sinon.stub().returns(true),
+			push: sinon.stub()
+		},
+		'./npm/enable-2fa': enable2faStub,
+		'./npm/publish': sinon.stub().returns({pipe: sinon.stub()})
+	});
+
+	await t.notThrowsAsync(np('1.0.0', {
+		...defaultOptions,
+		availability: {
+			isAvailable: true,
+			isUnknown: false
+		},
+		'2fa': false
+	}));
+
+	t.true(enable2faStub.notCalled);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -62,7 +62,7 @@ test('skip enabling 2FA if the package exists', async t => {
 	t.true(enable2faStub.notCalled);
 });
 
-test('skip enabling 2FA if the "2fa" option is false', async t => {
+test('skip enabling 2FA if the `2fa` option is false', async t => {
 	const enable2faStub = sinon.stub();
 
 	const np = proxyquire('../source', {


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

This adds a `--no-2fa` CLI option as discussed in #398 to bypass enabling 2FA on new packages.
The check is pretty trivial; if the 2Fa option is set to false, the task is skipped. Default value is true.

One of the reasons I'm wanting this is that I use `semantic-release` to handle releasing my packages, which requires not having 2fa enabled. I'm looking to use `np` for doing some pre-publishing of an upcoming package of mine, as `semantic-release` does not support `0.x.x` versions.

Fixes #398
Closes #515 (by superseding)