### PR TITLE
Create release draft even when pushing to protected branches failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "np",
-	"version": "6.3.2",
+	"version": "6.3.3",
 	"description": "A better `npm publish`",
 	"license": "MIT",
 	"repository": "sindresorhus/np",

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -126,8 +126,18 @@ exports.commitLogFromRevision = async revision => {
 	return stdout;
 };
 
-exports.push = async () => {
-	await execa('git', ['push', '--follow-tags']);
+exports.push = async remoteIsOnGitHub => {
+	try {
+		await execa('git', ['push', '--follow-tags']);
+	} catch (error) {
+		if (remoteIsOnGitHub && error.stderr && error.stderr.indexOf('remote: error: GH006: Protected branch update failed') === 0) {
+			// Try to push tags only, when commits can't be pushed due to branch protection
+			await execa('git', ['push', '--tags']);
+			return;
+		}
+
+		throw error;
+	}
 };
 
 exports.deleteTag = async tagName => {

--- a/source/index.js
+++ b/source/index.js
@@ -248,7 +248,7 @@ module.exports = async (input = 'patch', options) => {
 				return 'Couldn\'t publish package to npm; not pushing.';
 			}
 		},
-		task: () => git.push()
+		task: () => git.push(isOnGitHub)
 	});
 
 	tasks.add({

--- a/test/index.js
+++ b/test/index.js
@@ -45,7 +45,7 @@ test('skip enabling 2FA if the package exists', async t => {
 		'./git-tasks': sinon.stub(),
 		'./git-util': {
 			hasUpstream: sinon.stub().returns(true),
-			push: sinon.stub()
+			pushGraceful: sinon.stub()
 		},
 		'./npm/enable-2fa': enable2faStub,
 		'./npm/publish': sinon.stub().returns({pipe: sinon.stub()})


### PR DESCRIPTION
Fixes #502.

Setup for tests:
1. setup branch protection fro some playground repository
2. publish new version with `np`

The tags should be pushed and the release draft should be created.
