### PR TITLE
Change initial git checks to execute before showing interactive ui

### DIFF
--- a/source/cli.js
+++ b/source/cli.js
@@ -12,6 +12,8 @@ const version = require('./version');
 const util = require('./util');
 const ui = require('./ui');
 const np = require('.');
+const Listr = require('listr');
+const gitTasks = require('./git-tasks');
 
 const cli = meow(`
 	Usage
@@ -121,6 +123,15 @@ updateNotifier({pkg: cli.pkg}).notify();
 	};
 
 	const version = cli.input.length > 0 ? cli.input[0] : false;
+
+	const tasks = new Listr([
+		{
+			title: 'Git initial tasks',
+			task: () => gitTasks()
+		}
+	]);
+
+	await tasks.run();
 
 	const options = await ui({
 		...flags,

--- a/source/git-tasks.js
+++ b/source/git-tasks.js
@@ -2,11 +2,11 @@
 const Listr = require('listr');
 const git = require('./git-util');
 
-module.exports = options => {
+module.exports = () => {
 	const tasks = [
 		{
-			title: 'Check current branch',
-			task: () => git.verifyCurrentBranchIsReleaseBranch(options.branch)
+			title: 'Check git remote',
+			task: async () => git.verifyRemoteIsValid()
 		},
 		{
 			title: 'Check local working tree',
@@ -17,10 +17,6 @@ module.exports = options => {
 			task: () => git.verifyRemoteHistoryIsClean()
 		}
 	];
-
-	if (options.anyBranch) {
-		tasks.shift();
-	}
 
 	return new Listr(tasks);
 };

--- a/source/index.js
+++ b/source/index.js
@@ -17,7 +17,6 @@ const onetime = require('onetime');
 const exitHook = require('async-exit-hook');
 const logSymbols = require('log-symbols');
 const prerequisiteTasks = require('./prerequisite-tasks');
-const gitTasks = require('./git-tasks');
 const publish = require('./npm/publish');
 const enable2fa = require('./npm/enable-2fa');
 const npm = require('./npm/util');
@@ -104,10 +103,6 @@ module.exports = async (input = 'patch', options) => {
 			title: 'Prerequisite check',
 			enabled: () => options.runPublish,
 			task: () => prerequisiteTasks(input, pkg, options)
-		},
-		{
-			title: 'Git',
-			task: () => gitTasks(options)
 		}
 	], {
 		showSubtasks: false

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -53,8 +53,8 @@ module.exports = (input, pkg, options) => {
 			task: async () => git.verifyRecentGitVersion()
 		},
 		{
-			title: 'Check git remote',
-			task: async () => git.verifyRemoteIsValid()
+			title: 'Check current branch',
+			task: () => git.verifyCurrentBranchIsReleaseBranch(options.branch)
 		},
 		{
 			title: 'Validate version',

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -54,6 +54,7 @@ module.exports = (input, pkg, options) => {
 		},
 		{
 			title: 'Check current branch',
+			skip: () => options.anyBranch,
 			task: () => git.verifyCurrentBranchIsReleaseBranch(options.branch)
 		},
 		{

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -24,7 +24,6 @@ test.beforeEach(() => {
 	execaStub.resetStub();
 });
 
-
 test.serial('should fail when git remote does not exists', async t => {
 	execaStub.createStub([
 		{

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -214,6 +214,7 @@ test.serial('should not fail when current branch not master and publishing from 
 		},
 		{
 			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			exitCode: 0,
 			stdout: ''
 		}
 	]);

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -211,10 +211,14 @@ test.serial('should not fail when current branch not master and publishing from 
 			command: 'git rev-list --count --left-only @{u}...HEAD',
 			exitCode: 0,
 			stdout: ''
+		},
+		{
+			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+			stdout: ''
 		}
 	]);
 	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false, anyBranch: true}));
-	t.false(SilentRenderer.tasks.some(task => task.title === 'Check current branch'));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check current branch' && task.isSkipped()));
 });
 
 test.serial('should fail when version is invalid', async t => {

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -177,7 +177,7 @@ test.serial('should fail when release branch is not specified, current branch is
 			stdout: 'feature'
 		}
 	]);
-	await t.throwsAsync(run(testedModule({})),
+	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false})),
 		{message: 'Not on `main`/`master` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.'});
 	t.true(SilentRenderer.tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
 });
@@ -190,7 +190,7 @@ test.serial('should fail when current branch is not the specified release branch
 			stdout: 'feature'
 		}
 	]);
-	await t.throwsAsync(run(testedModule({branch: 'release'})),
+	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false, branch: 'release'})),
 		{message: 'Not on `release` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.'});
 	t.true(SilentRenderer.tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
 });
@@ -213,7 +213,7 @@ test.serial('should not fail when current branch not master and publishing from 
 			stdout: ''
 		}
 	]);
-	await run(testedModule({anyBranch: true}));
+	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false, anyBranch: true}));
 	t.false(SilentRenderer.tasks.some(task => task.title === 'Check current branch'));
 });
 

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -169,18 +169,52 @@ test.serial('should fail when git version does not match range in `package.json`
 	t.true(SilentRenderer.tasks.some(task => task.title === 'Check git version' && task.hasFailed()));
 });
 
-test.serial('should fail when git remote does not exists', async t => {
+test.serial('should fail when release branch is not specified, current branch is not main/master and publishing from any branch not permitted', async t => {
 	execaStub.createStub([
 		{
-			command: 'git ls-remote origin HEAD',
-			exitCode: 1,
-			exitCodeName: 'EPERM',
-			stderr: 'not found'
+			command: 'git symbolic-ref --short HEAD',
+			exitCode: 0,
+			stdout: 'feature'
 		}
 	]);
-	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
-		{message: 'not found'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check git remote' && task.hasFailed()));
+	await t.throwsAsync(run(testedModule({})),
+		{message: 'Not on `main`/`master` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.'});
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
+});
+
+test.serial('should fail when current branch is not the specified release branch and publishing from any branch not permitted', async t => {
+	execaStub.createStub([
+		{
+			command: 'git symbolic-ref --short HEAD',
+			exitCode: 0,
+			stdout: 'feature'
+		}
+	]);
+	await t.throwsAsync(run(testedModule({branch: 'release'})),
+		{message: 'Not on `release` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.'});
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
+});
+
+test.serial('should not fail when current branch not master and publishing from any branch permitted', async t => {
+	execaStub.createStub([
+		{
+			command: 'git symbolic-ref --short HEAD',
+			exitCode: 0,
+			stdout: 'feature'
+		},
+		{
+			command: 'git status --porcelain',
+			exitCode: 0,
+			stdout: ''
+		},
+		{
+			command: 'git rev-list --count --left-only @{u}...HEAD',
+			exitCode: 0,
+			stdout: ''
+		}
+	]);
+	await run(testedModule({anyBranch: true}));
+	t.false(SilentRenderer.tasks.some(task => task.title === 'Check current branch'));
 });
 
 test.serial('should fail when version is invalid', async t => {


### PR DESCRIPTION
Based on the discussion in #414 

This PR moves the `isRemoteValid`, and the `isWorkingTreeClean` and `checkUnpulledChanges` to run as an initial task before the ui is displayed. 
I also moved the `isValidBranch` check to execute in `pre-requisite tasks`. I feel like this is a better option and we can check this once `options` are finalized.
Moved the tests around to pass and satisfy the new changes.