### PR TITLE
Fix readme typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -284,7 +284,7 @@ If you're running into other issues when using SSH, please consult [GitHub's sup
 
 ### I get an error when publishing my package through Yarn
 
-If you an error like this…
+If you get an error like this…
 
 ```shell
 ❯ Prerequisite check


### PR DESCRIPTION
just saw a missing `get` while reading through the docs - boy scout rule and such...
