### PR TITLE
Standardize skipping and enabling tasks

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -117,7 +117,7 @@ module.exports = async (input = 'patch', options) => {
 		tasks.add([
 			{
 				title: 'Cleanup',
-				skip: () => hasLockFile,
+				enabled: () => !hasLockFile,
 				task: () => del('node_modules')
 			},
 			{
@@ -257,18 +257,18 @@ module.exports = async (input = 'patch', options) => {
 		}
 	});
 
-	tasks.add({
-		title: 'Creating release draft on GitHub',
-		enabled: () => isOnGitHub === true,
-		skip: () => {
-			if (options.preview) {
-				return '[Preview] GitHub Releases draft will not be opened in preview mode.';
-			}
-
-			return !options.releaseDraft;
-		},
-		task: () => releaseTaskHelper(options, pkg)
-	});
+	if (options.releaseDraft) {
+		tasks.add({
+			title: 'Creating release draft on GitHub',
+			enabled: () => isOnGitHub === true,
+			skip: () => {
+				if (options.preview) {
+					return '[Preview] GitHub Releases draft will not be opened in preview mode.';
+				}
+			},
+			task: () => releaseTaskHelper(options, pkg)
+		});
+	}
 
 	await tasks.run();
 

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -13,7 +13,7 @@ module.exports = (input, pkg, options) => {
 	const tasks = [
 		{
 			title: 'Ping npm registry',
-			skip: () => pkg.private || isExternalRegistry,
+			enabled: () => !pkg.private && !isExternalRegistry,
 			task: async () => npm.checkConnection()
 		},
 		{
@@ -30,7 +30,7 @@ module.exports = (input, pkg, options) => {
 		},
 		{
 			title: 'Verify user is authenticated',
-			skip: () => process.env.NODE_ENV === 'test' || pkg.private,
+			enabled: () => process.env.NODE_ENV !== 'test' && !pkg.private,
 			task: async () => {
 				const username = await npm.username({
 					externalRegistry: isExternalRegistry ? pkg.publishConfig.registry : false

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -38,7 +38,7 @@ test.serial('public-package published on npm registry: should fail when npm regi
 	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && task.hasFailed()));
 });
 
-test.serial('private package: should skip task pinging npm registry', async t => {
+test.serial('private package: should disable task pinging npm registry', async t => {
 	execaStub.createStub([
 		{
 			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
@@ -47,10 +47,10 @@ test.serial('private package: should skip task pinging npm registry', async t =>
 		}
 	]);
 	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && task.isSkipped()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && !task.isEnabled()));
 });
 
-test.serial('external registry: should skip task pinging npm registry', async t => {
+test.serial('external registry: should disable task pinging npm registry', async t => {
 	execaStub.createStub([
 		{
 			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
@@ -60,7 +60,7 @@ test.serial('external registry: should skip task pinging npm registry', async t 
 	]);
 	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', publishConfig: {registry: 'http://my.io'}},
 		{yarn: false}));
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && task.isSkipped()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && !task.isEnabled()));
 });
 
 test.serial('should fail when npm version does not match range in `package.json`', async t => {
@@ -141,7 +141,7 @@ test.serial('should fail when user is not authenticated at external registry', a
 	t.true(SilentRenderer.tasks.some(task => task.title === 'Verify user is authenticated' && task.hasFailed()));
 });
 
-test.serial('private package: should skip task `verify user is authenticated`', async t => {
+test.serial('private package: should disable task `verify user is authenticated`', async t => {
 	execaStub.createStub([
 		{
 			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
@@ -152,7 +152,7 @@ test.serial('private package: should skip task `verify user is authenticated`', 
 	process.env.NODE_ENV = 'P';
 	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
 	process.env.NODE_ENV = 'test';
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Verify user is authenticated' && task.isSkipped()));
+	t.true(SilentRenderer.tasks.some(task => task.title === 'Verify user is authenticated' && !task.isEnabled()));
 });
 
 test.serial('should fail when git version does not match range in `package.json`', async t => {


### PR DESCRIPTION
Standardizes the behavior of skipping and enabling tasks as discussed in https://github.com/sindresorhus/np/pull/513#issuecomment-696303588.

Apart from preview mode, there are now only two remaining cases where a task is skipped: “Pushing tags” when there’s no upstream branch ([source](https://github.com/sindresorhus/np/blob/5689d51ed1e7b0ad460f4bb4bd8cad6e9cd34a2c/source/index.js#L243-L245)) and when publishing failed ([source](https://github.com/sindresorhus/np/blob/5689d51ed1e7b0ad460f4bb4bd8cad6e9cd34a2c/source/index.js#L251-L253)). While the latter is certainly fine and expected, the former may be worthy of discussion. After all, the user may intentionally not have an upstream branch. For comparison, `np` also doesn’t skip “Running tests using npm” when there’s no `test` script.

Closes #513.