### PR TITLE
Fix error when Yarn cannot find test script

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -156,7 +156,7 @@ module.exports = async (input = 'patch', options) => {
 				enabled: () => options.yarn === true,
 				task: () => exec('yarn', testCommand).pipe(
 					catchError(error => {
-						if (error.message.includes(`Command “${testScript}” not found`)) {
+						if (error.message.includes(`Command "${testScript}" not found`)) {
 							return [];
 						}
 


### PR DESCRIPTION
At least with Yarn v1.22.10 (the latest v1), `yarn run` prints straight quotes instead of curly quotes.

This was originally changed with https://github.com/sindresorhus/np/commit/0c46a2f6894eac8a429b1f9c036113e8d2022eb3 due to the suggestion at https://github.com/sindresorhus/np/pull/557#discussion_r456980965.