### PR TITLE
Add `--release-draft-only` flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ $ np --help
     --no-yarn               Don't use Yarn
     --contents              Subdirectory to publish
     --no-release-draft      Skips opening a GitHub release draft
-    --release-draft-only    Only opens a GitHub release draft for the latest published version
+    --release-draft-only    Only opens a GitHub release draft
     --test-script           Name of npm run script to run tests before publishing (default: test)
     --no-2fa                Don't enable 2FA on new packages (not recommended)
 

--- a/readme.md
+++ b/readme.md
@@ -50,19 +50,20 @@ $ np --help
       patch | minor | major | prepatch | preminor | premajor | prerelease | 1.2.3
 
   Options
-    --any-branch        Allow publishing from any branch
-    --branch            Name of the release branch (default: master)
-    --no-cleanup        Skips cleanup of node_modules
-    --no-tests          Skips tests
-    --yolo              Skips cleanup and testing
-    --no-publish        Skips publishing
-    --preview           Show tasks without actually executing them
-    --tag               Publish under a given dist-tag
-    --no-yarn           Don't use Yarn
-    --contents          Subdirectory to publish
-    --no-release-draft  Skips opening a GitHub release draft
-    --test-script       Name of npm run script to run tests before publishing (default: test)
-    --no-2fa            Don't enable 2FA on new packages (not recommended)
+    --any-branch            Allow publishing from any branch
+    --branch                Name of the release branch (default: master)
+    --no-cleanup            Skips cleanup of node_modules
+    --no-tests              Skips tests
+    --yolo                  Skips cleanup and testing
+    --no-publish            Skips publishing
+    --preview               Show tasks without actually executing them
+    --tag                   Publish under a given dist-tag
+    --no-yarn               Don't use Yarn
+    --contents              Subdirectory to publish
+    --no-release-draft      Skips opening a GitHub release draft
+    --release-draft-only    Only opens a GitHub release draft for the latest published version
+    --test-script           Name of npm run script to run tests before publishing (default: test)
+    --no-2fa                Don't enable 2FA on new packages (not recommended)
 
   Examples
     $ np

--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -21,19 +21,20 @@ const cli = meow(`
 	    ${version.SEMVER_INCREMENTS.join(' | ')} | 1.2.3
 
 	Options
-	  --any-branch        Allow publishing from any branch
-	  --branch            Name of the release branch (default: master)
-	  --no-cleanup        Skips cleanup of node_modules
-	  --no-tests          Skips tests
-	  --yolo              Skips cleanup and testing
-	  --no-publish        Skips publishing
-	  --preview           Show tasks without actually executing them
-	  --tag               Publish under a given dist-tag
-	  --no-yarn           Don't use Yarn
-	  --contents          Subdirectory to publish
-	  --no-release-draft  Skips opening a GitHub release draft
-	  --test-script       Name of npm run script to run tests before publishing (default: test)
-	  --no-2fa            Don't enable 2FA on new packages (not recommended)
+	  --any-branch           Allow publishing from any branch
+	  --branch               Name of the release branch (default: master)
+	  --no-cleanup           Skips cleanup of node_modules
+	  --no-tests             Skips tests
+	  --yolo                 Skips cleanup and testing
+	  --no-publish           Skips publishing
+	  --preview              Show tasks without actually executing them
+	  --tag                  Publish under a given dist-tag
+	  --no-yarn              Don't use Yarn
+	  --contents             Subdirectory to publish
+	  --no-release-draft     Skips opening a GitHub release draft
+	  --release-draft-only   Only opens a GitHub release draft for the latest published version
+	  --test-script          Name of npm run script to run tests before publishing (default: test)
+	  --no-2fa               Don't enable 2FA on new packages (not recommended)
 
 	Examples
 	  $ np
@@ -63,6 +64,9 @@ const cli = meow(`
 			type: 'boolean'
 		},
 		releaseDraft: {
+			type: 'boolean'
+		},
+		releaseDraftOnly: {
 			type: 'boolean'
 		},
 		tag: {
@@ -113,14 +117,15 @@ updateNotifier({pkg: cli.pkg}).notify();
 		flags['2fa'] = flags['2Fa'];
 	}
 
-	const runPublish = flags.publish && !pkg.private;
+	const runPublish = !flags.releaseDraftOnly && flags.publish && !pkg.private;
 
 	const availability = flags.publish ? await isPackageNameAvailable(pkg) : {
 		isAvailable: false,
 		isUnknown: false
 	};
 
-	const version = cli.input.length > 0 ? cli.input[0] : false;
+	// Use current (latest) version when 'releaseDraftOnly', otherwise use the first argument.
+	const version = flags.releaseDraftOnly ? pkg.version : cli.input.length > 0 ? cli.input[0] : false;
 
 	const options = await ui({
 		...flags,

--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -125,7 +125,7 @@ updateNotifier({pkg: cli.pkg}).notify();
 	};
 
 	// Use current (latest) version when 'releaseDraftOnly', otherwise use the first argument.
-	const version = flags.releaseDraftOnly ? pkg.version : cli.input.length > 0 ? cli.input[0] : false;
+	const version = flags.releaseDraftOnly ? pkg.version : (cli.input.length > 0 ? cli.input[0] : false);
 
 	const options = await ui({
 		...flags,

--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -141,7 +141,7 @@ updateNotifier({pkg: cli.pkg}).notify();
 	console.log(); // Prints a newline for readability
 	const newPkg = await np(options.version, options);
 
-	if (options.preview) {
+	if (options.preview || options.releaseDraftOnly) {
 		return;
 	}
 

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -42,7 +42,7 @@ exports.tagBeforeCurrentOrFirstCommit = async () => {
 	}
 
 	return tags[tags.length - 2];
-}
+};
 
 exports.latestTagOrFirstCommit = async () => {
 	let latest;

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -34,7 +34,7 @@ exports.tagBeforeCurrentOrFirstCommit = async () => {
 	const tags = stdout.split('\n');
 
 	if (tags.length === 0) {
-		return null;
+		return;
 	}
 
 	if (tags.length === 1) {

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -29,6 +29,21 @@ const firstCommit = async () => {
 	return stdout;
 };
 
+exports.tagBeforeCurrentOrFirstCommit = async () => {
+	const {stdout} = await execa('git', ['tag']);
+	const tags = stdout.split('\n');
+
+	if (tags.length === 0) {
+		return null;
+	}
+
+	if (tags.length === 1) {
+		return firstCommit();
+	}
+
+	return tags[tags.length - 2];
+}
+
 exports.latestTagOrFirstCommit = async () => {
 	let latest;
 	try {

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -29,7 +29,7 @@ const firstCommit = async () => {
 	return stdout;
 };
 
-exports.tagBeforeCurrentOrFirstCommit = async () => {
+exports.previousTagOrFirstCommit = async () => {
 	const {stdout} = await execa('git', ['tag']);
 	const tags = stdout.split('\n');
 

--- a/source/ui.js
+++ b/source/ui.js
@@ -14,8 +14,7 @@ const prettyVersionDiff = require('./pretty-version-diff');
 const printCommitLog = async (repoUrl, registryUrl, latestTag) => {
 	const revision = latestTag ? await git.latestTagOrFirstCommit() : await git.tagBeforeCurrentOrFirstCommit();
 	if (revision === null) {
-		console.error(`The package hasn't been published yet.`);
-		process.exit(1);
+		throw new Error('The package hasn\'t been published yet.');
 	}
 
 	const log = await git.commitLogFromRevision(revision);

--- a/source/ui.js
+++ b/source/ui.js
@@ -196,6 +196,22 @@ module.exports = async (options, pkg) => {
 	const useLatestTag = !options.releaseDraftOnly;
 	const {hasCommits, releaseNotes} = await printCommitLog(repoUrl, registryUrl, useLatestTag);
 
+	if (hasCommits && options.releaseDraftOnly) {
+		const answers = await inquirer.prompt([{
+			type: 'confirm',
+			name: 'confirm',
+			message: 'Unreleased commits found. They won\'t be included in the release draft, continue?',
+			default: false
+		}]);
+
+		if (!answers.confirm) {
+			return {
+				...options,
+				...answers
+			};
+		}
+	}
+
 	if (options.version) {
 		return {
 			...options,

--- a/source/ui.js
+++ b/source/ui.js
@@ -26,6 +26,8 @@ const printCommitLog = async (repoUrl, registryUrl, fromLatestTag) => {
 		};
 	}
 
+	let commitRangeText = `${revision}...master`;
+
 	let commits = log.split('\n')
 		.map(commit => {
 			const splitIndex = commit.lastIndexOf(' ');
@@ -37,6 +39,8 @@ const printCommitLog = async (repoUrl, registryUrl, fromLatestTag) => {
 
 	if (!fromLatestTag) {
 		const latestTag = await git.latestTag();
+		commitRangeText = `${revision}...${latestTag}`;
+
 		const versionBumpCommitName = latestTag.slice(1); // Name v1.0.1 becomes 1.0.1
 		const versionBumpCommitIndex = commits.findIndex(commit => commit.message === versionBumpCommitName);
 
@@ -54,7 +58,7 @@ const printCommitLog = async (repoUrl, registryUrl, fromLatestTag) => {
 		`- ${htmlEscape(commit.message)}  ${commit.id}`
 	).join('\n') + `\n\n${repoUrl}/compare/${revision}...${nextTag}`;
 
-	const commitRange = util.linkifyCommitRange(repoUrl, `${revision}...master`);
+	const commitRange = util.linkifyCommitRange(repoUrl, commitRangeText);
 
 	console.log(`${chalk.bold('Commits:')}\n${history}\n\n${chalk.bold('Commit Range:')}\n${commitRange}\n\n${chalk.bold('Registry:')}\n${registryUrl}\n`);
 

--- a/source/ui.js
+++ b/source/ui.js
@@ -14,7 +14,7 @@ const prettyVersionDiff = require('./pretty-version-diff');
 const printCommitLog = async (repoUrl, registryUrl, fromLatestTag) => {
 	const revision = fromLatestTag ? await git.latestTagOrFirstCommit() : await git.previousTagOrFirstCommit();
 	if (!revision) {
-		throw new Error('The package hasn\'t been published yet.');
+		throw new Error('The package has not been published yet.');
 	}
 
 	const log = await git.commitLogFromRevision(revision);
@@ -204,7 +204,7 @@ module.exports = async (options, pkg) => {
 		const answers = await inquirer.prompt([{
 			type: 'confirm',
 			name: 'confirm',
-			message: 'Unreleased commits found. They won\'t be included in the release draft, continue?',
+			message: 'Unreleased commits found. They won\'t be included in the release draft. Continue?',
 			default: false
 		}]);
 

--- a/source/ui.js
+++ b/source/ui.js
@@ -13,7 +13,7 @@ const prettyVersionDiff = require('./pretty-version-diff');
 
 const printCommitLog = async (repoUrl, registryUrl, latestTag) => {
 	const revision = latestTag ? await git.latestTagOrFirstCommit() : await git.tagBeforeCurrentOrFirstCommit();
-	if (revision === null) {
+	if (!revision) {
 		throw new Error('The package hasn\'t been published yet.');
 	}
 


### PR DESCRIPTION
Closes #478 

This is my proposal for the issue above.

- It adds the argument `--release-draft-only` to the CLI
- It adds the function `previousTagOrFirstCommit()` to get the tag which is before the one which we would have usually used
- Error if no tag found, which means the package hasn't been published yet
- Unreleased commits are ignored

Example of use case:

- **First commit**
- **Some changes**
- **1.0.0** (tag = v1.0.0)
- **More changes**
- **Bug fix**
- **1.0.1** (tag = v1.0.1) *(published on NPM, no release on GitHub)*
- **One last fix** *(unreleased)*

I do `np --release-draft-only`.

Behind the scenes, the np command is called with version **1.0.1** ["in mind"](https://github.com/sindresorhus/np/compare/master...Drarig29:master#diff-355e06507da68dfbe299f31276e205eac3ea53a573c6578cf1ec6ec7ac18b4dfR127-R128).

The function `previousTagOrFirstCommit()` returns **1.0.0** so that we can get the commit log from this revision.

The commit which bumps the version to the latest (named "1.0.1") is [removed from the history](https://github.com/sindresorhus/np/compare/master...Drarig29:master#diff-3d9cecf1b2714d924301260ff5f7e9dc12aa4ef4504c6a4e33b1451b1c20fd5fR38-R44) as well as the unreleased commit(s).

No other task is executed. The [release draft helper runs](https://github.com/sindresorhus/np/pull/578/commits/516c89ece474e7f3729b97c175aeeeaf23aabd5c#diff-88a99604221821c7258fe9c24fc58a4ef42242b97aeae97d6c438db3f62be6cdR61-R65) right after the first prompt.