### PR TITLE
Check if yarn.lock is ignored before throwing error

### DIFF
--- a/source/git-util.js
+++ b/source/git-util.js
@@ -187,6 +187,8 @@ exports.checkIfFileGitIgnored = async pathToFile => {
 		const {stdout} = await execa('git', ['check-ignore', pathToFile]);
 		return Boolean(stdout);
 	} catch (error) {
+		// If file is not ignored, git check-ignore throws empty error and exits.
+		// Check that and return false so as not to throw an unwanted error
 		if (error.stdout === '' && error.stderr === '') {
 			return false;
 		}

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -185,12 +185,7 @@ exports.verifyRecentGitVersion = async () => {
 exports.checkIfFileGitIgnored = async pathToFile => {
 	try {
 		const {stdout} = await execa('git', ['check-ignore', pathToFile]);
-
-		if (stdout) {
-			return true;
-		}
-
-		return false;
+		return Boolean(stdout);
 	} catch (error) {
 		if (error.stdout === '' && error.stderr === '') {
 			return false;

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -187,8 +187,8 @@ exports.checkIfFileGitIgnored = async pathToFile => {
 		const {stdout} = await execa('git', ['check-ignore', pathToFile]);
 		return Boolean(stdout);
 	} catch (error) {
-		// If file is not ignored, git check-ignore throws empty error and exits.
-		// Check that and return false so as not to throw an unwanted error
+		// If file is not ignored, `git check-ignore` throws an empty error and exits.
+		// Check that and return false so as not to throw an unwanted error.
 		if (error.stdout === '' && error.stderr === '') {
 			return false;
 		}

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -181,3 +181,21 @@ exports.verifyRecentGitVersion = async () => {
 
 	verifyRequirementSatisfied('git', installedVersion);
 };
+
+exports.checkIfFileGitIgnored = async pathToFile => {
+	try {
+		const {stdout} = await execa('git', ['check-ignore', pathToFile]);
+
+		if (stdout) {
+			return true;
+		}
+
+		return false;
+	} catch (error) {
+		if (error.stdout === '' && error.stderr === '') {
+			return false;
+		}
+
+		throw error;
+	}
+};

--- a/source/index.js
+++ b/source/index.js
@@ -129,6 +129,7 @@ module.exports = async (input = 'patch', options) => {
 							if ((!error.stderr.startsWith('error Your lockfile needs to be updated'))) {
 								return;
 							}
+
 							if (await git.checkIfFileGitIgnored('yarn.lock')) {
 								return;
 							}

--- a/source/index.js
+++ b/source/index.js
@@ -126,12 +126,14 @@ module.exports = async (input = 'patch', options) => {
 				task: () => {
 					return exec('yarn', ['install', '--frozen-lockfile', '--production=false']).pipe(
 						catchError(async error => {
-							if (error.stderr.startsWith('error Your lockfile needs to be updated')) {
-								const isIgnored = await git.checkIfFileGitIgnored('yarn.lock');
-								if (!isIgnored) {
-									throw new Error('yarn.lock file is outdated. Run yarn, commit the updated lockfile and try again.');
-								}
+							if ((!error.stderr.startsWith('error Your lockfile needs to be updated'))) {
+								return;
 							}
+							if (await git.checkIfFileGitIgnored('yarn.lock')) {
+								return;
+							}
+
+							throw new Error('yarn.lock file is outdated. Run yarn, commit the updated lockfile and try again.');
 						})
 					);
 				}

--- a/source/index.js
+++ b/source/index.js
@@ -123,15 +123,18 @@ module.exports = async (input = 'patch', options) => {
 			{
 				title: 'Installing dependencies using Yarn',
 				enabled: () => options.yarn === true,
-				task: () => exec('yarn', ['install', '--frozen-lockfile', '--production=false']).pipe(
-					catchError(error => {
-						if (error.stderr.startsWith('error Your lockfile needs to be updated')) {
-							return throwError(new Error('yarn.lock file is outdated. Run yarn, commit the updated lockfile and try again.'));
-						}
-
-						return throwError(error);
-					})
-				)
+				task: () => {
+					return exec('yarn', ['install', '--frozen-lockfile', '--production=false']).pipe(
+						catchError(async error => {
+							if (error.stderr.startsWith('error Your lockfile needs to be updated')) {
+								const isIgnored = await git.checkIfFileGitIgnored('yarn.lock');
+								if (!isIgnored) {
+									throw new Error('yarn.lock file is outdated. Run yarn, commit the updated lockfile and try again.');
+								}
+							}
+						})
+					);
+				}
 			},
 			{
 				title: 'Installing dependencies using npm',


### PR DESCRIPTION
Fixes #573.

Checks if `yarn.lock` is gitignored before throwing `yarn.lock file is outdated. Run yarn, commit the updated lockfile and try again.`
