### PR TITLE
Fix `--release-draft-only` flag

### DIFF
--- a/source/git-util.js
+++ b/source/git-util.js
@@ -85,6 +85,15 @@ exports.verifyCurrentBranchIsReleaseBranch = async releaseBranch => {
 	}
 };
 
+exports.isHeadDetached = async () => {
+	try {
+		await execa('git', ['symbolic-ref', '-q', 'HEAD']);
+		return false;
+	} catch {
+		return true;
+	}
+}
+
 exports.isWorkingTreeClean = async () => {
 	try {
 		const {stdout: status} = await execa('git', ['status', '--porcelain']);

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -30,7 +30,7 @@ const firstCommit = async () => {
 };
 
 exports.previousTagOrFirstCommit = async () => {
-	const {stdout} = await execa('git', ['tag']);
+	const {stdout} = await execa('git', ['for-each-ref', '--sort=creatordate', '--format', '%(refname:strip=2)', 'refs/tags']);
 	const tags = stdout.split('\n');
 
 	if (tags.length === 0) {
@@ -41,7 +41,15 @@ exports.previousTagOrFirstCommit = async () => {
 		return firstCommit();
 	}
 
-	return tags[tags.length - 2];
+	try {
+		// Return the tag before the latest one.
+		const latest = await exports.latestTag();
+		const index = tags.indexOf(latest);
+		return tags[index - 1];
+	} catch {
+		// Fallback to the first commit.
+		return firstCommit();
+	}
 };
 
 exports.latestTagOrFirstCommit = async () => {

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -43,7 +43,7 @@ exports.previousTagOrFirstCommit = async () => {
 	try {
 		// Return the tag before the latest one.
 		const latest = await exports.latestTag();
-		const index = tags.findIndex(tag => tag === latest);
+		const index = tags.indexOf(latest);
 		return tags[index - 1];
 	} catch {
 		// Fallback to the first commit.
@@ -85,6 +85,7 @@ exports.verifyCurrentBranchIsReleaseBranch = async releaseBranch => {
 };
 
 exports.tagList = async () => {
+	// Returns the list of tags, sorted by creation date in ascending order.
 	const {stdout} = await execa('git', ['tag', '--sort=creatordate']);
 	return stdout.split('\n');
 };
@@ -92,7 +93,7 @@ exports.tagList = async () => {
 exports.isHeadDetached = async () => {
 	try {
 		// Command will fail with code 1 if the HEAD is detached.
-		await execa('git', ['symbolic-ref', 'HEAD']);
+		await execa('git', ['symbolic-ref', '--quiet', 'HEAD']);
 		return false;
 	} catch {
 		return true;

--- a/source/ui.js
+++ b/source/ui.js
@@ -51,6 +51,10 @@ const printCommitLog = async (repoUrl, registryUrl, fromLatestTag) => {
 			hasUnreleasedCommits = true;
 		}
 
+		if (await git.isHeadDetached()) {
+			commitRangeText = `${revision}...${latestTag}`;
+		}
+
 		// Get rid of unreleased commits and of the version bump commit.
 		commits = commits.slice(versionBumpCommitIndex + 1);
 	}

--- a/source/ui.js
+++ b/source/ui.js
@@ -41,7 +41,9 @@ const printCommitLog = async (repoUrl, registryUrl, fromLatestTag) => {
 
 	if (!fromLatestTag) {
 		const latestTag = await git.latestTag();
-		const versionBumpCommitName = latestTag.slice(1); // Name v1.0.1 becomes 1.0.1
+
+		// Version bump commit created by np, following the semver specification.
+		const versionBumpCommitName = latestTag.match(/v\d+\.\d+\.\d+/) && latestTag.slice(1); // Name v1.0.1 becomes 1.0.1
 		const versionBumpCommitIndex = commits.findIndex(commit => commit.message === versionBumpCommitName);
 
 		if (versionBumpCommitIndex > 0) {


### PR DESCRIPTION
Fixes #593 

Here is the result with the repo [GhostText](https://github.com/GhostText/GhostText/) :

```
$ gh repo clone GhostText/GhostText
$ git checkout 17.12.11.910
$ np --release-draft-only

Create a release draft on GitHub for GhostText-browser (current: 0.0.0)

Commits:
- Fix: highlight text field when the connection happens, not when the field is focused  d88c3f7
- Feature: Automatically skip invisible textareas  b35eae9
- Fix: Remove unsupported blur event from CodeMirror  3cacd7d
- Refactor: Drop google-specific contenteditable  88f55ca
- Feature: support more contenteditable elements across the page  873f7c3
- Add HTML page for tests  e3df6ce
- Revert "Disable extensions-only deployment condition"  5726259
- Readme: improve usage  c07e2c8
- Readme: formatting/wording improvements  df91d5e
- Disable extensions-only deployment condition  30cac4f
- Update license  a05af1a
- Disable keyboard shortcut in Firefox (#121)  d5822b6
- Readme: added contribution plea  9d8d3d1
- Readme: added plugin for neovim (#115)  eb90e0c
- Readme: add link to Acme client (#108)  5380d8a

Commit Range:
17.10.25.1400...17.12.11.910

Registry:
https://registry.npmjs.org/



✖ You need to specify either the `repoUrl` option or both the `user` and `repo` options
```

The remaining problems are not related to the `--release-draft-only` flag.