### PR TITLE
Add .cjs file ending for config file locations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ Run `np` without arguments to launch the interactive UI that guides you through 
 
 ## Config
 
-`np` can be configured both locally and globally. When using the global `np` binary, you can configure any of the CLI flags in either a `.np-config.js` or `.np-config.json` file in the home directory. When using the local `np` binary, for example, in a `npm run` script, you can configure `np` by setting the flags in either a top-level `np` field in `package.json` or in a `.np-config.js` or `.np-config.json` file in the project directory. If it exists, the local installation will always take precedence. This ensures any local config matches the version of `np` it was designed for.
+`np` can be configured both locally and globally. When using the global `np` binary, you can configure any of the CLI flags in either a `.np-config.js`, `.np-config.cjs` or `.np-config.json` file in the home directory. When using the local `np` binary, for example, in a `npm run` script, you can configure `np` by setting the flags in either a top-level `np` field in `package.json` or in a `.np-config.js`, `.np-config.cjs` or `.np-config.json` file in the project directory. If it exists, the local installation will always take precedence. This ensures any local config matches the version of `np` it was designed for.
 
 Currently, these are the flags you can configure:
 
@@ -120,7 +120,7 @@ For example, this configures `np` to never use Yarn and to use `dist` as the sub
 }
 ```
 
-`.np-config.js`
+`.np-config.js` or `.np-config.cjs`
 ```js
 module.exports = {
 	yarn: false,

--- a/source/config.js
+++ b/source/config.js
@@ -6,7 +6,7 @@ const {cosmiconfig} = require('cosmiconfig');
 
 module.exports = async () => {
 	const searchDir = isInstalledGlobally ? os.homedir() : await pkgDir();
-	const searchPlaces = ['.np-config.json', '.np-config.js'];
+	const searchPlaces = ['.np-config.json', '.np-config.js', '.np-config.cjs'];
 	if (!isInstalledGlobally) {
 		searchPlaces.push('package.json');
 	}

--- a/test/config.js
+++ b/test/config.js
@@ -8,7 +8,8 @@ const fixtureBasePath = path.resolve('test', 'fixtures', 'config');
 const getConfigsWhenGlobalBinaryIsUsed = async homedirStub => {
 	const pathsPkgDir = [path.resolve(fixtureBasePath, 'pkg-dir'),
 		path.resolve(fixtureBasePath, 'local1'),
-		path.resolve(fixtureBasePath, 'local2')];
+		path.resolve(fixtureBasePath, 'local2'),
+		path.resolve(fixtureBasePath, 'local3')];
 
 	const promises = [];
 	pathsPkgDir.forEach(pathPkgDir => {
@@ -27,7 +28,8 @@ const getConfigsWhenGlobalBinaryIsUsed = async homedirStub => {
 
 const getConfigsWhenLocalBinaryIsUsed = async pathPkgDir => {
 	const homedirs = [path.resolve(fixtureBasePath, 'homedir1'),
-		path.resolve(fixtureBasePath, 'homedir2')];
+		path.resolve(fixtureBasePath, 'homedir2'),
+		path.resolve(fixtureBasePath, 'homedir3')];
 
 	const promises = [];
 	homedirs.forEach(homedir => {
@@ -60,7 +62,7 @@ test('returns config from home directory when global binary is used and `.np-con
 	configs.forEach(config => t.deepEqual(config, {source: 'homedir/.np-config.js'}));
 });
 
-test('returns config from home directory when global binary is used and `.np-config.js` exists in home directory', async t => {
+test('returns config from home directory when global binary is used and `.np-config.cjs` exists in home directory', async t => {
 	const homedirStub = sinon.stub();
 	homedirStub.returns(path.resolve(fixtureBasePath, 'homedir3'));
 	const configs = await getConfigsWhenGlobalBinaryIsUsed(homedirStub);
@@ -82,7 +84,7 @@ test('returns config from package directory when local binary is used and `.np-c
 	configs.forEach(config => t.deepEqual(config, {source: 'packagedir/.np-config.js'}));
 });
 
-test('returns config from package directory when local binary is used and `.np-config.js` exists in package directory', async t => {
+test('returns config from package directory when local binary is used and `.np-config.cjs` exists in package directory', async t => {
 	const configs = await getConfigsWhenLocalBinaryIsUsed(path.resolve(fixtureBasePath, 'local3'));
 	configs.forEach(config => t.deepEqual(config, {source: 'packagedir/.np-config.cjs'}));
 });

--- a/test/config.js
+++ b/test/config.js
@@ -60,6 +60,13 @@ test('returns config from home directory when global binary is used and `.np-con
 	configs.forEach(config => t.deepEqual(config, {source: 'homedir/.np-config.js'}));
 });
 
+test('returns config from home directory when global binary is used and `.np-config.js` exists in home directory', async t => {
+	const homedirStub = sinon.stub();
+	homedirStub.returns(path.resolve(fixtureBasePath, 'homedir3'));
+	const configs = await getConfigsWhenGlobalBinaryIsUsed(homedirStub);
+	configs.forEach(config => t.deepEqual(config, {source: 'homedir/.np-config.cjs'}));
+});
+
 test('returns config from package directory when local binary is used and `package.json` exists in package directory', async t => {
 	const configs = await getConfigsWhenLocalBinaryIsUsed(path.resolve(fixtureBasePath, 'pkg-dir'));
 	configs.forEach(config => t.deepEqual(config, {source: 'package.json'}));
@@ -73,4 +80,9 @@ test('returns config from package directory when local binary is used and `.np-c
 test('returns config from package directory when local binary is used and `.np-config.js` exists in package directory', async t => {
 	const configs = await getConfigsWhenLocalBinaryIsUsed(path.resolve(fixtureBasePath, 'local2'));
 	configs.forEach(config => t.deepEqual(config, {source: 'packagedir/.np-config.js'}));
+});
+
+test('returns config from package directory when local binary is used and `.np-config.js` exists in package directory', async t => {
+	const configs = await getConfigsWhenLocalBinaryIsUsed(path.resolve(fixtureBasePath, 'local3'));
+	configs.forEach(config => t.deepEqual(config, {source: 'packagedir/.np-config.cjs'}));
 });

--- a/test/fixtures/config/homedir3/.np-config.cjs
+++ b/test/fixtures/config/homedir3/.np-config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	source: 'homedir/.np-config.cjs'
+};

--- a/test/fixtures/config/local3/.np-config.cjs
+++ b/test/fixtures/config/local3/.np-config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	source: 'packagedir/.np-config.cjs'
+};


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

Maybe I'm missing something, but I can't get .np-config.js files to work in a folder with `type: module` in the package.json. This should fix that issue and also isn't inferring with anything else here AFAIK.

I also thought about adding the possibility for .mjs config files, for users without `type: module` but which want to write their config file in es module syntax. But that can also be in a seperate pull request and I wanted to keep it simple for now.