### PR TITLE
ESM migration (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"type": "module",
 	"funding": "https://github.com/sindresorhus/np?sponsor=1",
 	"bin": "source/cli.js",
+	"exports": "./source/index.js",
 	"engines": {
 		"node": ">=12",
 		"npm": ">=6.8.0",
@@ -14,7 +15,7 @@
 		"yarn": ">=1.7.0"
 	},
 	"scripts": {
-		"test": "xo && FORCE_HYPERLINK=1 ava"
+		"test": "NODE_OPTIONS=--experimental-json-modules FORCE_HYPERLINK=1 ava"
 	},
 	"files": [
 		"source"
@@ -72,7 +73,7 @@
 		"update-notifier": "^5.0.1"
 	},
 	"devDependencies": {
-		"ava": "^2.3.0",
+		"ava": "3",
 		"execa_test_double": "^4.0.1",
 		"mockery": "^2.1.0",
 		"proxyquire": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
 	"description": "A better `npm publish`",
 	"license": "MIT",
 	"repository": "sindresorhus/np",
+	"type": "module",
 	"funding": "https://github.com/sindresorhus/np?sponsor=1",
 	"bin": "source/cli.js",
 	"engines": {
-		"node": ">=10",
+		"node": ">=12",
 		"npm": ">=6.8.0",
 		"git": ">=2.11.0",
 		"yarn": ">=1.7.0"

--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -1,18 +1,17 @@
 #!/usr/bin/env node
-'use strict';
-// eslint-disable-next-line import/no-unassigned-import
-require('symbol-observable'); // Important: This needs to be first to prevent weird Observable incompatibilities
-const logSymbols = require('log-symbols');
-const meow = require('meow');
-const updateNotifier = require('update-notifier');
-const hasYarn = require('has-yarn');
-const config = require('./config');
-const git = require('./git-util');
-const {isPackageNameAvailable} = require('./npm/util');
-const version = require('./version');
-const util = require('./util');
-const ui = require('./ui');
-const np = require('.');
+
+import 'symbol-observable';
+import logSymbols from 'log-symbols';
+import meow from 'meow';
+import updateNotifier from 'update-notifier';
+import hasYarn from 'has-yarn';
+import config from './config';
+import * as git from './git-util';
+import {isPackageNameAvailable} from './npm/util';
+import version from './version';
+import * as util from './util';
+import ui from './ui';
+import np from '.';
 
 const cli = meow(`
 	Usage
@@ -94,12 +93,9 @@ const cli = meow(`
 		}
 	}
 });
-
 updateNotifier({pkg: cli.pkg}).notify();
-
 (async () => {
 	const pkg = util.readPkg();
-
 	const defaultFlags = {
 		cleanup: true,
 		tests: true,
@@ -108,30 +104,24 @@ updateNotifier({pkg: cli.pkg}).notify();
 		yarn: hasYarn(),
 		'2fa': true
 	};
-
 	const localConfig = await config();
-
 	const flags = {
 		...defaultFlags,
 		...localConfig,
 		...cli.flags
 	};
-
 	// Workaround for unintended auto-casing behavior from `meow`.
 	if ('2Fa' in flags) {
 		flags['2fa'] = flags['2Fa'];
 	}
 
 	const runPublish = !flags.releaseDraftOnly && flags.publish && !pkg.private;
-
 	const availability = flags.publish ? await isPackageNameAvailable(pkg) : {
 		isAvailable: false,
 		isUnknown: false
 	};
-
 	// Use current (latest) version when 'releaseDraftOnly', otherwise use the first argument.
 	const version = flags.releaseDraftOnly ? pkg.version : (cli.input.length > 0 ? cli.input[0] : false);
-
 	const branch = flags.branch || await git.defaultBranch();
 	const options = await ui({
 		...flags,
@@ -140,14 +130,12 @@ updateNotifier({pkg: cli.pkg}).notify();
 		runPublish,
 		branch
 	}, pkg);
-
 	if (!options.confirm) {
 		process.exit(0);
 	}
 
 	console.log(); // Prints a newline for readability
 	const newPkg = await np(options.version, options);
-
 	if (options.preview || options.releaseDraftOnly) {
 		return;
 	}

--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -5,15 +5,16 @@ import logSymbols from 'log-symbols';
 import meow from 'meow';
 import updateNotifier from 'update-notifier';
 import hasYarn from 'has-yarn';
-import config from './config';
-import * as git from './git-util';
-import {isPackageNameAvailable} from './npm/util';
-import version from './version';
-import * as util from './util';
-import ui from './ui';
+import config from './config.js';
+import * as git from './git-util.js';
+import {isPackageNameAvailable} from './npm/util.js';
+import version from './version.js';
+import * as util from './util.js';
+import ui from './ui.js';
 import np from '.';
 
-const cli = meow(`
+const cli = meow(
+	`
 	Usage
 	  $ np <version>
 
@@ -43,56 +44,58 @@ const cli = meow(`
 	  $ np 1.0.2
 	  $ np 1.0.2-beta.3 --tag=beta
 	  $ np 1.0.2-beta.3 --tag=beta --contents=dist
-`, {
-	booleanDefault: undefined,
-	flags: {
-		anyBranch: {
-			type: 'boolean'
-		},
-		branch: {
-			type: 'string'
-		},
-		cleanup: {
-			type: 'boolean'
-		},
-		tests: {
-			type: 'boolean'
-		},
-		yolo: {
-			type: 'boolean'
-		},
-		publish: {
-			type: 'boolean'
-		},
-		releaseDraft: {
-			type: 'boolean'
-		},
-		releaseDraftOnly: {
-			type: 'boolean'
-		},
-		tag: {
-			type: 'string'
-		},
-		yarn: {
-			type: 'boolean'
-		},
-		contents: {
-			type: 'string'
-		},
-		preview: {
-			type: 'boolean'
-		},
-		testScript: {
-			type: 'string'
-		},
-		'2fa': {
-			type: 'boolean'
-		},
-		message: {
-			type: 'string'
+`,
+	{
+		booleanDefault: undefined,
+		flags: {
+			anyBranch: {
+				type: 'boolean'
+			},
+			branch: {
+				type: 'string'
+			},
+			cleanup: {
+				type: 'boolean'
+			},
+			tests: {
+				type: 'boolean'
+			},
+			yolo: {
+				type: 'boolean'
+			},
+			publish: {
+				type: 'boolean'
+			},
+			releaseDraft: {
+				type: 'boolean'
+			},
+			releaseDraftOnly: {
+				type: 'boolean'
+			},
+			tag: {
+				type: 'string'
+			},
+			yarn: {
+				type: 'boolean'
+			},
+			contents: {
+				type: 'string'
+			},
+			preview: {
+				type: 'boolean'
+			},
+			testScript: {
+				type: 'string'
+			},
+			'2fa': {
+				type: 'boolean'
+			},
+			message: {
+				type: 'string'
+			}
 		}
 	}
-});
+);
 updateNotifier({pkg: cli.pkg}).notify();
 (async () => {
 	const pkg = util.readPkg();
@@ -116,20 +119,29 @@ updateNotifier({pkg: cli.pkg}).notify();
 	}
 
 	const runPublish = !flags.releaseDraftOnly && flags.publish && !pkg.private;
-	const availability = flags.publish ? await isPackageNameAvailable(pkg) : {
-		isAvailable: false,
-		isUnknown: false
-	};
+	const availability = flags.publish ?
+		await isPackageNameAvailable(pkg) :
+		{
+			isAvailable: false,
+			isUnknown: false
+		  };
 	// Use current (latest) version when 'releaseDraftOnly', otherwise use the first argument.
-	const version = flags.releaseDraftOnly ? pkg.version : (cli.input.length > 0 ? cli.input[0] : false);
-	const branch = flags.branch || await git.defaultBranch();
-	const options = await ui({
-		...flags,
-		availability,
-		version,
-		runPublish,
-		branch
-	}, pkg);
+	const version = flags.releaseDraftOnly ?
+		pkg.version :
+		(cli.input.length > 0 ?
+			cli.input[0] :
+			false);
+	const branch = flags.branch || (await git.defaultBranch());
+	const options = await ui(
+		{
+			...flags,
+			availability,
+			version,
+			runPublish,
+			branch
+		},
+		pkg
+	);
 	if (!options.confirm) {
 		process.exit(0);
 	}

--- a/source/cli.js
+++ b/source/cli.js
@@ -2,7 +2,7 @@
 import {debuglog} from 'util';
 import importLocal from 'import-local';
 import isInstalledGlobally from 'is-installed-globally';
-import './cli-implementation';
+import './cli-implementation.js';
 
 const log = debuglog('np');
 // Prefer the local installation

--- a/source/cli.js
+++ b/source/cli.js
@@ -1,17 +1,13 @@
 #!/usr/bin/env node
-'use strict';
-const {debuglog} = require('util');
-const importLocal = require('import-local');
-const isInstalledGlobally = require('is-installed-globally');
+import {debuglog} from 'util';
+import importLocal from 'import-local';
+import isInstalledGlobally from 'is-installed-globally';
+import './cli-implementation';
 
 const log = debuglog('np');
-
 // Prefer the local installation
 if (!importLocal(__filename)) {
 	if (isInstalledGlobally) {
 		log('Using global install of np.');
 	}
-
-	// eslint-disable-next-line import/no-unassigned-import
-	require('./cli-implementation');
 }

--- a/source/config.js
+++ b/source/config.js
@@ -1,10 +1,11 @@
-'use strict';
-const os = require('os');
-const isInstalledGlobally = require('is-installed-globally');
-const pkgDir = require('pkg-dir');
-const {cosmiconfig} = require('cosmiconfig');
+import os from 'os';
+import isInstalledGlobally from 'is-installed-globally';
+import pkgDir from 'pkg-dir';
+import cosmiconfig$0 from 'cosmiconfig';
 
-module.exports = async () => {
+const {cosmiconfig} = cosmiconfig$0;
+
+const config = async () => {
 	const searchDir = isInstalledGlobally ? os.homedir() : await pkgDir();
 	const searchPlaces = ['.np-config.json', '.np-config.js', '.np-config.cjs'];
 	if (!isInstalledGlobally) {
@@ -16,6 +17,7 @@ module.exports = async () => {
 		stopDir: searchDir
 	});
 	const {config} = (await explorer.search(searchDir)) || {};
-
 	return config;
 };
+
+export default config;

--- a/source/git-tasks.js
+++ b/source/git-tasks.js
@@ -1,8 +1,7 @@
-'use strict';
-const Listr = require('listr');
-const git = require('./git-util');
+import Listr from 'listr';
+import * as git from './git-util';
 
-module.exports = options => {
+const gitTasks = options => {
 	const tasks = [
 		{
 			title: 'Check current branch',
@@ -17,10 +16,11 @@ module.exports = options => {
 			task: () => git.verifyRemoteHistoryIsClean()
 		}
 	];
-
 	if (options.anyBranch) {
 		tasks.shift();
 	}
 
 	return new Listr(tasks);
 };
+
+export default gitTasks;

--- a/source/git-tasks.js
+++ b/source/git-tasks.js
@@ -1,5 +1,5 @@
 import Listr from 'listr';
-import * as git from './git-util';
+import * as git from './git-util.js';
 
 const gitTasks = options => {
 	const tasks = [

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -1,12 +1,15 @@
-
 import execa from 'execa';
 import escapeStringRegexp from 'escape-string-regexp';
 import ignoreWalker from 'ignore-walk';
 import pkgDir from 'pkg-dir';
-import {verifyRequirementSatisfied} from './version';
+import {verifyRequirementSatisfied} from './version.js';
 
 const firstCommit = async () => {
-	const {stdout} = await execa('git', ['rev-list', '--max-parents=0', 'HEAD']);
+	const {stdout} = await execa('git', [
+		'rev-list',
+		'--max-parents=0',
+		'HEAD'
+	]);
 	return stdout;
 };
 
@@ -37,12 +40,21 @@ export const latestTag = async () => {
 
 export const newFilesSinceLastRelease = async () => {
 	try {
-		const {stdout} = await execa('git', ['diff', '--name-only', '--diff-filter=A', await this.latestTag(), 'HEAD']);
+		const {stdout} = await execa('git', [
+			'diff',
+			'--name-only',
+			'--diff-filter=A',
+			await this.latestTag(),
+			'HEAD'
+		]);
 		if (stdout.trim().length === 0) {
 			return [];
 		}
 
-		const result = stdout.trim().split('\n').map(row => row.trim());
+		const result = stdout
+			.trim()
+			.split('\n')
+			.map(row => row.trim());
 		return result;
 	} catch {
 		// Get all files under version control
@@ -88,9 +100,18 @@ export const latestTagOrFirstCommit = async () => {
 };
 
 export const hasUpstream = async () => {
-	const escapedCurrentBranch = escapeStringRegexp(await exports.currentBranch());
-	const {stdout} = await execa('git', ['status', '--short', '--branch', '--porcelain']);
-	return new RegExp(String.raw`^## ${escapedCurrentBranch}\.\.\..+\/${escapedCurrentBranch}`).test(stdout);
+	const escapedCurrentBranch = escapeStringRegexp(
+		await exports.currentBranch()
+	);
+	const {stdout} = await execa('git', [
+		'status',
+		'--short',
+		'--branch',
+		'--porcelain'
+	]);
+	return new RegExp(
+		String.raw`^## ${escapedCurrentBranch}\.\.\..+\/${escapedCurrentBranch}`
+	).test(stdout);
 };
 
 export const currentBranch = async () => {
@@ -101,7 +122,9 @@ export const currentBranch = async () => {
 export const verifyCurrentBranchIsReleaseBranch = async releaseBranch => {
 	const currentBranch = await exports.currentBranch();
 	if (currentBranch !== releaseBranch) {
-		throw new Error(`Not on \`${releaseBranch}\` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.`);
+		throw new Error(
+			`Not on \`${releaseBranch}\` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.`
+		);
 	}
 };
 
@@ -142,10 +165,16 @@ export const verifyWorkingTreeIsClean = async () => {
 
 export const isRemoteHistoryClean = async () => {
 	let history;
-	try { // Gracefully handle no remote set up.
-		const {stdout} = await execa('git', ['rev-list', '--count', '--left-only', '@{u}...HEAD']);
+	try {
+		// Gracefully handle no remote set up.
+		const {stdout} = await execa('git', [
+			'rev-list',
+			'--count',
+			'--left-only',
+			'@{u}...HEAD'
+		]);
 		history = stdout;
-	} catch { }
+	} catch {}
 
 	if (history && history !== '0') {
 		return false;
@@ -174,7 +203,12 @@ export const fetch = async () => {
 
 export const tagExistsOnRemote = async tagName => {
 	try {
-		const {stdout: revInfo} = await execa('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagName}`]);
+		const {stdout: revInfo} = await execa('git', [
+			'rev-parse',
+			'--quiet',
+			'--verify',
+			`refs/tags/${tagName}`
+		]);
 		if (revInfo) {
 			return true;
 		}
@@ -199,7 +233,9 @@ export const defaultBranch = async () => {
 		}
 	}
 
-	throw new Error('Could not infer the default Git branch. Please specify one with the --branch flag or with a np config.');
+	throw new Error(
+		'Could not infer the default Git branch. Please specify one with the --branch flag or with a np config.'
+	);
 };
 
 export const verifyTagDoesNotExistOnRemote = async tagName => {
@@ -209,7 +245,11 @@ export const verifyTagDoesNotExistOnRemote = async tagName => {
 };
 
 export const commitLogFromRevision = async revision => {
-	const {stdout} = await execa('git', ['log', '--format=%s %h', `${revision}..HEAD`]);
+	const {stdout} = await execa('git', [
+		'log',
+		'--format=%s %h',
+		`${revision}..HEAD`
+	]);
 	return stdout;
 };
 
@@ -220,7 +260,11 @@ export const pushGraceful = async remoteIsOnGitHub => {
 		if (remoteIsOnGitHub && error.stderr && error.stderr.includes('GH006')) {
 			// Try to push tags only, when commits can't be pushed due to branch protection
 			await execa('git', ['push', '--tags']);
-			return {pushed: 'tags', reason: 'Branch protection: np can`t push the commits. Push them manually.'};
+			return {
+				pushed: 'tags',
+				reason:
+					'Branch protection: np can`t push the commits. Push them manually.'
+			};
 		}
 
 		throw error;

--- a/source/npm/enable-2fa.js
+++ b/source/npm/enable-2fa.js
@@ -1,12 +1,11 @@
-'use strict';
-const execa = require('execa');
-const {from} = require('rxjs');
-const {catchError} = require('rxjs/operators');
-const handleNpmError = require('./handle-npm-error');
+import execa from 'execa';
+import * as rxjs from 'rxjs';
+import {catchError} from 'rxjs/operators';
+import handleNpmError from './handle-npm-error';
 
+const {from} = rxjs;
 const getEnable2faArgs = (packageName, options) => {
 	const args = ['access', '2fa-required', packageName];
-
 	if (options && options.otp) {
 		args.push('--otp', options.otp);
 	}
@@ -15,10 +14,6 @@ const getEnable2faArgs = (packageName, options) => {
 };
 
 const enable2fa = (packageName, options) => execa('npm', getEnable2faArgs(packageName, options));
-
-module.exports = (task, packageName, options) =>
-	from(enable2fa(packageName, options)).pipe(
-		catchError(error => handleNpmError(error, task, otp => enable2fa(packageName, {otp})))
-	);
-
-module.exports.getEnable2faArgs = getEnable2faArgs;
+const enable2faForPkg = (task, packageName, options) => from(enable2fa(packageName, options)).pipe(catchError(error => handleNpmError(error, task, otp => enable2fa(packageName, {otp}))));
+export default enable2faForPkg;
+export {getEnable2faArgs};

--- a/source/npm/enable-2fa.js
+++ b/source/npm/enable-2fa.js
@@ -1,7 +1,7 @@
 import execa from 'execa';
 import * as rxjs from 'rxjs';
-import {catchError} from 'rxjs/operators';
-import handleNpmError from './handle-npm-error';
+import {catchError} from 'rxjs/operators/index.js';
+import handleNpmError from './handle-npm-error.js';
 
 const {from} = rxjs;
 const getEnable2faArgs = (packageName, options) => {
@@ -13,7 +13,13 @@ const getEnable2faArgs = (packageName, options) => {
 	return args;
 };
 
-const enable2fa = (packageName, options) => execa('npm', getEnable2faArgs(packageName, options));
-const enable2faForPkg = (task, packageName, options) => from(enable2fa(packageName, options)).pipe(catchError(error => handleNpmError(error, task, otp => enable2fa(packageName, {otp}))));
+const enable2fa = (packageName, options) =>
+	execa('npm', getEnable2faArgs(packageName, options));
+const enable2faForPkg = (task, packageName, options) =>
+	from(enable2fa(packageName, options)).pipe(
+		catchError(error =>
+			handleNpmError(error, task, otp => enable2fa(packageName, {otp}))
+		)
+	);
 export default enable2faForPkg;
 export {getEnable2faArgs};

--- a/source/npm/handle-npm-error.js
+++ b/source/npm/handle-npm-error.js
@@ -1,8 +1,8 @@
-const listrInput = require('listr-input');
-const chalk = require('chalk');
-const {throwError} = require('rxjs');
-const {catchError} = require('rxjs/operators');
-
+import listrInput from 'listr-input';
+import chalk from 'chalk';
+import * as rxjs from 'rxjs';
+import {catchError} from 'rxjs/operators';
+const {throwError} = rxjs;
 const handleNpmError = (error, task, message, executor) => {
 	if (typeof message === 'function') {
 		executor = message;
@@ -13,19 +13,16 @@ const handleNpmError = (error, task, message, executor) => {
 	if (error.stderr.includes('one-time pass') || error.stdout.includes('Two factor authentication')) {
 		const {title} = task;
 		task.title = `${title} ${chalk.yellow('(waiting for input…)')}`;
-
 		return listrInput('Enter OTP:', {
 			done: otp => {
 				task.title = title;
 				return executor(otp);
 			},
 			autoSubmit: value => value.length === 6
-		}).pipe(
-			catchError(error => handleNpmError(error, task, 'OTP was incorrect, try again:', executor))
-		);
+		}).pipe(catchError(error => handleNpmError(error, task, 'OTP was incorrect, try again:', executor)));
 	}
 
 	return throwError(error);
 };
 
-module.exports = handleNpmError;
+export default handleNpmError;

--- a/source/npm/handle-npm-error.js
+++ b/source/npm/handle-npm-error.js
@@ -1,7 +1,7 @@
 import listrInput from 'listr-input';
 import chalk from 'chalk';
 import * as rxjs from 'rxjs';
-import {catchError} from 'rxjs/operators';
+import {catchError} from 'rxjs/operators/index.js';
 const {throwError} = rxjs;
 const handleNpmError = (error, task, message, executor) => {
 	if (typeof message === 'function') {
@@ -10,7 +10,10 @@ const handleNpmError = (error, task, message, executor) => {
 	}
 
 	// `one-time pass` is for npm and `Two factor authentication` is for Yarn.
-	if (error.stderr.includes('one-time pass') || error.stdout.includes('Two factor authentication')) {
+	if (
+		error.stderr.includes('one-time pass') ||
+		error.stdout.includes('Two factor authentication')
+	) {
 		const {title} = task;
 		task.title = `${title} ${chalk.yellow('(waiting for input…)')}`;
 		return listrInput('Enter OTP:', {
@@ -19,7 +22,11 @@ const handleNpmError = (error, task, message, executor) => {
 				return executor(otp);
 			},
 			autoSubmit: value => value.length === 6
-		}).pipe(catchError(error => handleNpmError(error, task, 'OTP was incorrect, try again:', executor)));
+		}).pipe(
+			catchError(error =>
+				handleNpmError(error, task, 'OTP was incorrect, try again:', executor)
+			)
+		);
 	}
 
 	return throwError(error);

--- a/source/npm/publish.js
+++ b/source/npm/publish.js
@@ -1,7 +1,7 @@
 import execa from 'execa';
 import * as rxjs from 'rxjs';
-import {catchError} from 'rxjs/operators';
-import handleNpmError from './handle-npm-error';
+import {catchError} from 'rxjs/operators/index.js';
+import handleNpmError from './handle-npm-error.js';
 
 const {from} = rxjs;
 const getPackagePublishArguments = options => {
@@ -25,11 +25,17 @@ const getPackagePublishArguments = options => {
 	return args;
 };
 
-const pkgPublish = (pkgManager, options) => execa(pkgManager, getPackagePublishArguments(options));
-const publish = (context, pkgManager, task, options) => from(pkgPublish(pkgManager, options)).pipe(catchError(error => handleNpmError(error, task, otp => {
-	context.otp = otp;
-	return pkgPublish(pkgManager, {...options, otp});
-})));
+const pkgPublish = (pkgManager, options) =>
+	execa(pkgManager, getPackagePublishArguments(options));
+const publish = (context, pkgManager, task, options) =>
+	from(pkgPublish(pkgManager, options)).pipe(
+		catchError(error =>
+			handleNpmError(error, task, otp => {
+				context.otp = otp;
+				return pkgPublish(pkgManager, {...options, otp});
+			})
+		)
+	);
 
 export default publish;
 

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -1,16 +1,16 @@
-'use strict';
-const fs = require('fs');
-const path = require('path');
-const execa = require('execa');
-const pTimeout = require('p-timeout');
-const {default: ow} = require('ow');
-const npmName = require('npm-name');
-const chalk = require('chalk');
-const pkgDir = require('pkg-dir');
-const ignoreWalker = require('ignore-walk');
-const minimatch = require('minimatch');
-const {verifyRequirementSatisfied} = require('../version');
+import fs from 'fs';
+import path from 'path';
+import execa from 'execa';
+import pTimeout from 'p-timeout';
+import ow$0 from 'ow';
+import npmName from 'npm-name';
+import chalk from 'chalk';
+import pkgDir from 'pkg-dir';
+import ignoreWalker from 'ignore-walk';
+import minimatch from 'minimatch';
+import {verifyRequirementSatisfied} from '../version';
 
+const {default: ow} = ow$0;
 // According to https://docs.npmjs.com/files/package.json#files
 // npm's default behavior is to ignore these files.
 const filesIgnoredByDefault = [
@@ -33,122 +33,6 @@ const filesIgnoredByDefault = [
 	'.git/**/*',
 	'.git'
 ];
-
-exports.checkConnection = () => pTimeout(
-	(async () => {
-		try {
-			await execa('npm', ['ping']);
-			return true;
-		} catch {
-			throw new Error('Connection to npm registry failed');
-		}
-	})(),
-	15000,
-	'Connection to npm registry timed out'
-);
-
-exports.username = async ({externalRegistry}) => {
-	const args = ['whoami'];
-
-	if (externalRegistry) {
-		args.push('--registry', externalRegistry);
-	}
-
-	try {
-		const {stdout} = await execa('npm', args);
-		return stdout;
-	} catch (error) {
-		throw new Error(/ENEEDAUTH/.test(error.stderr) ?
-			'You must be logged in. Use `npm login` and try again.' :
-			'Authentication error. Use `npm whoami` to troubleshoot.');
-	}
-};
-
-exports.collaborators = async pkg => {
-	const packageName = pkg.name;
-	ow(packageName, ow.string);
-
-	const args = ['access', 'ls-collaborators', packageName];
-	if (exports.isExternalRegistry(pkg)) {
-		args.push('--registry', pkg.publishConfig.registry);
-	}
-
-	try {
-		const {stdout} = await execa('npm', args);
-		return stdout;
-	} catch (error) {
-		// Ignore non-existing package error
-		if (error.stderr.includes('code E404')) {
-			return false;
-		}
-
-		throw error;
-	}
-};
-
-exports.prereleaseTags = async packageName => {
-	ow(packageName, ow.string);
-
-	let tags = [];
-	try {
-		const {stdout} = await execa('npm', ['view', '--json', packageName, 'dist-tags']);
-		tags = Object.keys(JSON.parse(stdout))
-			.filter(tag => tag !== 'latest');
-	} catch (error) {
-		if (((JSON.parse(error.stdout) || {}).error || {}).code !== 'E404') {
-			throw error;
-		}
-	}
-
-	if (tags.length === 0) {
-		tags.push('next');
-	}
-
-	return tags;
-};
-
-exports.isPackageNameAvailable = async pkg => {
-	const args = [pkg.name];
-	const availability = {
-		isAvailable: false,
-		isUnknown: false
-	};
-
-	if (exports.isExternalRegistry(pkg)) {
-		args.push({
-			registryUrl: pkg.publishConfig.registry
-		});
-	}
-
-	try {
-		availability.isAvailable = await npmName(...args) || false;
-	} catch {
-		availability.isUnknown = true;
-	}
-
-	return availability;
-};
-
-exports.isExternalRegistry = pkg => typeof pkg.publishConfig === 'object' && typeof pkg.publishConfig.registry === 'string';
-
-exports.version = async () => {
-	const {stdout} = await execa('npm', ['--version']);
-	return stdout;
-};
-
-exports.verifyRecentNpmVersion = async () => {
-	const npmVersion = await exports.version();
-	verifyRequirementSatisfied('npm', npmVersion);
-};
-
-exports.checkIgnoreStrategy = ({files}) => {
-	if (!files && !npmignoreExistsInPackageRootDir()) {
-		console.log(`
-		\n${chalk.bold.yellow('Warning:')} No ${chalk.bold.cyan('files')} field specified in ${chalk.bold.magenta('package.json')} nor is a ${chalk.bold.magenta('.npmignore')} file present. Having one of those will prevent you from accidentally publishing development-specific files along with your package's source code to npm.
-		`);
-	}
-};
-
 function npmignoreExistsInPackageRootDir() {
 	const rootDir = pkgDir.sync();
 	return fs.existsSync(path.resolve(rootDir, '.npmignore'));
@@ -183,7 +67,7 @@ function getFilesNotIncludedInFilesProperty(pkg, fileList) {
 			if (fs.statSync(path.resolve(rootDir, glob)).isDirectory()) {
 				globArrayForFilesAndDirectories.push(`${glob}/**/*`);
 			}
-		} catch {}
+		} catch { }
 	}
 
 	const result = fileList.filter(minimatch.filter(getIgnoredFilesGlob(globArrayForFilesAndDirectories, pkg.directories), {matchBase: true, dot: true}));
@@ -198,7 +82,7 @@ function getFilesIncludedInFilesProperty(pkg, fileList) {
 			if (fs.statSync(path.resolve(rootDir, glob)).isDirectory()) {
 				globArrayForFilesAndDirectories.push(`${glob}/**/*`);
 			}
-		} catch {}
+		} catch { }
 	}
 
 	return filterFileList(globArrayForFilesAndDirectories, fileList);
@@ -239,8 +123,112 @@ function getIgnoredFilesGlob(globArrayFromFilesProperty, packageDirectories) {
 	return `!{${globArrayFromFilesProperty.join(',')},${filesIgnoredByDefault.join(',')},${testDirectoriesGlob}}`;
 }
 
-// Get all files which will be ignored by either `.npmignore` or the `files` property in `package.json` (if defined).
-exports.getNewAndUnpublishedFiles = async (pkg, newFiles = []) => {
+export const checkConnection = () => pTimeout((async () => {
+	try {
+		await execa('npm', ['ping']);
+		return true;
+	} catch {
+		throw new Error('Connection to npm registry failed');
+	}
+})(), 15000, 'Connection to npm registry timed out');
+export const username = async ({externalRegistry}) => {
+	const args = ['whoami'];
+	if (externalRegistry) {
+		args.push('--registry', externalRegistry);
+	}
+
+	try {
+		const {stdout} = await execa('npm', args);
+		return stdout;
+	} catch (error) {
+		throw new Error(/ENEEDAUTH/.test(error.stderr) ?
+			'You must be logged in. Use `npm login` and try again.' :
+			'Authentication error. Use `npm whoami` to troubleshoot.');
+	}
+};
+
+export const collaborators = async pkg => {
+	const packageName = pkg.name;
+	ow(packageName, ow.string);
+	const args = ['access', 'ls-collaborators', packageName];
+	if (exports.isExternalRegistry(pkg)) {
+		args.push('--registry', pkg.publishConfig.registry);
+	}
+
+	try {
+		const {stdout} = await execa('npm', args);
+		return stdout;
+	} catch (error) {
+		// Ignore non-existing package error
+		if (error.stderr.includes('code E404')) {
+			return false;
+		}
+
+		throw error;
+	}
+};
+
+export const prereleaseTags = async packageName => {
+	ow(packageName, ow.string);
+	let tags = [];
+	try {
+		const {stdout} = await execa('npm', ['view', '--json', packageName, 'dist-tags']);
+		tags = Object.keys(JSON.parse(stdout))
+			.filter(tag => tag !== 'latest');
+	} catch (error) {
+		if (((JSON.parse(error.stdout) || {}).error || {}).code !== 'E404') {
+			throw error;
+		}
+	}
+
+	if (tags.length === 0) {
+		tags.push('next');
+	}
+
+	return tags;
+};
+
+export const isPackageNameAvailable = async pkg => {
+	const args = [pkg.name];
+	const availability = {
+		isAvailable: false,
+		isUnknown: false
+	};
+	if (exports.isExternalRegistry(pkg)) {
+		args.push({
+			registryUrl: pkg.publishConfig.registry
+		});
+	}
+
+	try {
+		availability.isAvailable = await npmName(...args) || false;
+	} catch {
+		availability.isUnknown = true;
+	}
+
+	return availability;
+};
+
+export const isExternalRegistry = pkg => typeof pkg.publishConfig === 'object' && typeof pkg.publishConfig.registry === 'string';
+export const version = async () => {
+	const {stdout} = await execa('npm', ['--version']);
+	return stdout;
+};
+
+export const verifyRecentNpmVersion = async () => {
+	const npmVersion = await exports.version();
+	verifyRequirementSatisfied('npm', npmVersion);
+};
+
+export const checkIgnoreStrategy = ({files}) => {
+	if (!files && !npmignoreExistsInPackageRootDir()) {
+		console.log(`
+		\n${chalk.bold.yellow('Warning:')} No ${chalk.bold.cyan('files')} field specified in ${chalk.bold.magenta('package.json')} nor is a ${chalk.bold.magenta('.npmignore')} file present. Having one of those will prevent you from accidentally publishing development-specific files along with your package's source code to npm.
+		`);
+	}
+};
+
+export const getNewAndUnpublishedFiles = async (pkg, newFiles = []) => {
 	if (pkg.files) {
 		return getFilesNotIncludedInFilesProperty(pkg, newFiles);
 	}
@@ -250,7 +238,7 @@ exports.getNewAndUnpublishedFiles = async (pkg, newFiles = []) => {
 	}
 };
 
-exports.getFirstTimePublishedFiles = async (pkg, newFiles = []) => {
+export const getFirstTimePublishedFiles = async (pkg, newFiles = []) => {
 	let result;
 	if (pkg.files) {
 		result = getFilesIncludedInFilesProperty(pkg, newFiles);
@@ -263,7 +251,7 @@ exports.getFirstTimePublishedFiles = async (pkg, newFiles = []) => {
 	return result.filter(minimatch.filter(`!{${filesIgnoredByDefault}}`, {matchBase: true, dot: true})).filter(minimatch.filter(getDefaultIncludedFilesGlob(pkg.main), {nocase: true, matchBase: true}));
 };
 
-exports.getRegistryUrl = async (pkgManager, pkg) => {
+export const getRegistryUrl = async (pkgManager, pkg) => {
 	const args = ['config', 'get', 'registry'];
 	if (exports.isExternalRegistry(pkg)) {
 		args.push('--registry');

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -8,7 +8,7 @@ import chalk from 'chalk';
 import pkgDir from 'pkg-dir';
 import ignoreWalker from 'ignore-walk';
 import minimatch from 'minimatch';
-import {verifyRequirementSatisfied} from '../version';
+import {verifyRequirementSatisfied} from '../version.js';
 
 const {default: ow} = ow$0;
 // According to https://docs.npmjs.com/files/package.json#files
@@ -43,12 +43,19 @@ async function getFilesIgnoredByDotnpmignore(pkg, fileList) {
 		path: pkgDir.sync(),
 		ignoreFiles: ['.npmignore']
 	});
-	return fileList.filter(minimatch.filter(getIgnoredFilesGlob(allowList, pkg.directories), {matchBase: true, dot: true}));
+	return fileList.filter(
+		minimatch.filter(getIgnoredFilesGlob(allowList, pkg.directories), {
+			matchBase: true,
+			dot: true
+		})
+	);
 }
 
 function filterFileList(globArray, fileList) {
 	const globString = globArray.length > 1 ? `{${globArray}}` : globArray[0];
-	return fileList.filter(minimatch.filter(globString, {matchBase: true, dot: true})); // eslint-disable-line unicorn/no-fn-reference-in-iterator
+	return fileList.filter(
+		minimatch.filter(globString, {matchBase: true, dot: true})
+	); // eslint-disable-line unicorn/no-fn-reference-in-iterator
 }
 
 async function getFilesIncludedByDotnpmignore(pkg, fileList) {
@@ -67,11 +74,21 @@ function getFilesNotIncludedInFilesProperty(pkg, fileList) {
 			if (fs.statSync(path.resolve(rootDir, glob)).isDirectory()) {
 				globArrayForFilesAndDirectories.push(`${glob}/**/*`);
 			}
-		} catch { }
+		} catch {}
 	}
 
-	const result = fileList.filter(minimatch.filter(getIgnoredFilesGlob(globArrayForFilesAndDirectories, pkg.directories), {matchBase: true, dot: true}));
-	return result.filter(minimatch.filter(getDefaultIncludedFilesGlob(pkg.main), {nocase: true, matchBase: true}));
+	const result = fileList.filter(
+		minimatch.filter(
+			getIgnoredFilesGlob(globArrayForFilesAndDirectories, pkg.directories),
+			{matchBase: true, dot: true}
+		)
+	);
+	return result.filter(
+		minimatch.filter(getDefaultIncludedFilesGlob(pkg.main), {
+			nocase: true,
+			matchBase: true
+		})
+	);
 }
 
 function getFilesIncludedInFilesProperty(pkg, fileList) {
@@ -82,7 +99,7 @@ function getFilesIncludedInFilesProperty(pkg, fileList) {
 			if (fs.statSync(path.resolve(rootDir, glob)).isDirectory()) {
 				globArrayForFilesAndDirectories.push(`${glob}/**/*`);
 			}
-		} catch { }
+		} catch {}
 	}
 
 	return filterFileList(globArrayForFilesAndDirectories, fileList);
@@ -113,24 +130,34 @@ function getIgnoredFilesGlob(globArrayFromFilesProperty, packageDirectories) {
 	let testDirectoriesGlob = '';
 	if (packageDirectories && Array.isArray(packageDirectories.test)) {
 		testDirectoriesGlob = packageDirectories.test.join(',');
-	} else if (packageDirectories && typeof packageDirectories.test === 'string') {
+	} else if (
+		packageDirectories &&
+		typeof packageDirectories.test === 'string'
+	) {
 		testDirectoriesGlob = packageDirectories.test;
 	} else {
 		// Fallback to `test` directory
 		testDirectoriesGlob = 'test/**/*';
 	}
 
-	return `!{${globArrayFromFilesProperty.join(',')},${filesIgnoredByDefault.join(',')},${testDirectoriesGlob}}`;
+	return `!{${globArrayFromFilesProperty.join(
+		','
+	)},${filesIgnoredByDefault.join(',')},${testDirectoriesGlob}}`;
 }
 
-export const checkConnection = () => pTimeout((async () => {
-	try {
-		await execa('npm', ['ping']);
-		return true;
-	} catch {
-		throw new Error('Connection to npm registry failed');
-	}
-})(), 15000, 'Connection to npm registry timed out');
+export const checkConnection = () =>
+	pTimeout(
+		(async () => {
+			try {
+				await execa('npm', ['ping']);
+				return true;
+			} catch {
+				throw new Error('Connection to npm registry failed');
+			}
+		})(),
+		15000,
+		'Connection to npm registry timed out'
+	);
 export const username = async ({externalRegistry}) => {
 	const args = ['whoami'];
 	if (externalRegistry) {
@@ -141,9 +168,11 @@ export const username = async ({externalRegistry}) => {
 		const {stdout} = await execa('npm', args);
 		return stdout;
 	} catch (error) {
-		throw new Error(/ENEEDAUTH/.test(error.stderr) ?
-			'You must be logged in. Use `npm login` and try again.' :
-			'Authentication error. Use `npm whoami` to troubleshoot.');
+		throw new Error(
+			/ENEEDAUTH/.test(error.stderr) ?
+				'You must be logged in. Use `npm login` and try again.' :
+				'Authentication error. Use `npm whoami` to troubleshoot.'
+		);
 	}
 };
 
@@ -172,9 +201,13 @@ export const prereleaseTags = async packageName => {
 	ow(packageName, ow.string);
 	let tags = [];
 	try {
-		const {stdout} = await execa('npm', ['view', '--json', packageName, 'dist-tags']);
-		tags = Object.keys(JSON.parse(stdout))
-			.filter(tag => tag !== 'latest');
+		const {stdout} = await execa('npm', [
+			'view',
+			'--json',
+			packageName,
+			'dist-tags'
+		]);
+		tags = Object.keys(JSON.parse(stdout)).filter(tag => tag !== 'latest');
 	} catch (error) {
 		if (((JSON.parse(error.stdout) || {}).error || {}).code !== 'E404') {
 			throw error;
@@ -201,7 +234,7 @@ export const isPackageNameAvailable = async pkg => {
 	}
 
 	try {
-		availability.isAvailable = await npmName(...args) || false;
+		availability.isAvailable = (await npmName(...args)) || false;
 	} catch {
 		availability.isUnknown = true;
 	}
@@ -209,7 +242,9 @@ export const isPackageNameAvailable = async pkg => {
 	return availability;
 };
 
-export const isExternalRegistry = pkg => typeof pkg.publishConfig === 'object' && typeof pkg.publishConfig.registry === 'string';
+export const isExternalRegistry = pkg =>
+	typeof pkg.publishConfig === 'object' &&
+	typeof pkg.publishConfig.registry === 'string';
 export const version = async () => {
 	const {stdout} = await execa('npm', ['--version']);
 	return stdout;
@@ -223,7 +258,13 @@ export const verifyRecentNpmVersion = async () => {
 export const checkIgnoreStrategy = ({files}) => {
 	if (!files && !npmignoreExistsInPackageRootDir()) {
 		console.log(`
-		\n${chalk.bold.yellow('Warning:')} No ${chalk.bold.cyan('files')} field specified in ${chalk.bold.magenta('package.json')} nor is a ${chalk.bold.magenta('.npmignore')} file present. Having one of those will prevent you from accidentally publishing development-specific files along with your package's source code to npm.
+		\n${chalk.bold.yellow('Warning:')} No ${chalk.bold.cyan(
+	'files'
+)} field specified in ${chalk.bold.magenta(
+	'package.json'
+)} nor is a ${chalk.bold.magenta(
+	'.npmignore'
+)} file present. Having one of those will prevent you from accidentally publishing development-specific files along with your package's source code to npm.
 		`);
 	}
 };
@@ -248,7 +289,19 @@ export const getFirstTimePublishedFiles = async (pkg, newFiles = []) => {
 		result = newFiles;
 	}
 
-	return result.filter(minimatch.filter(`!{${filesIgnoredByDefault}}`, {matchBase: true, dot: true})).filter(minimatch.filter(getDefaultIncludedFilesGlob(pkg.main), {nocase: true, matchBase: true}));
+	return result
+		.filter(
+			minimatch.filter(`!{${filesIgnoredByDefault}}`, {
+				matchBase: true,
+				dot: true
+			})
+		)
+		.filter(
+			minimatch.filter(getDefaultIncludedFilesGlob(pkg.main), {
+				nocase: true,
+				matchBase: true
+			})
+		);
 };
 
 export const getRegistryUrl = async (pkgManager, pkg) => {

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -1,9 +1,9 @@
 import Listr from 'listr';
 import execa from 'execa';
-import version from './version';
-import * as git from './git-util';
-import * as npm from './npm/util';
-import {getTagVersionPrefix} from './util';
+import version from './version.js';
+import * as git from './git-util.js';
+import * as npm from './npm/util.js';
+import {getTagVersionPrefix} from './util.js';
 
 const prerequisiteTasks = (input, pkg, options) => {
 	const isExternalRegistry = npm.isExternalRegistry(pkg);
@@ -31,7 +31,9 @@ const prerequisiteTasks = (input, pkg, options) => {
 			enabled: () => process.env.NODE_ENV !== 'test' && !pkg.private,
 			task: async () => {
 				const username = await npm.username({
-					externalRegistry: isExternalRegistry ? pkg.publishConfig.registry : false
+					externalRegistry: isExternalRegistry ?
+						pkg.publishConfig.registry :
+						false
 				});
 				const collaborators = await npm.collaborators(pkg);
 				if (!collaborators) {
@@ -41,7 +43,9 @@ const prerequisiteTasks = (input, pkg, options) => {
 				const json = JSON.parse(collaborators);
 				const permissions = json[username];
 				if (!permissions || !permissions.includes('write')) {
-					throw new Error('You do not have write permissions required to publish this package.');
+					throw new Error(
+						'You do not have write permissions required to publish this package.'
+					);
 				}
 			}
 		},
@@ -57,20 +61,32 @@ const prerequisiteTasks = (input, pkg, options) => {
 			title: 'Validate version',
 			task: () => {
 				if (!version.isValidInput(input)) {
-					throw new Error(`Version should be either ${version.SEMVER_INCREMENTS.join(', ')}, or a valid semver version.`);
+					throw new Error(
+						`Version should be either ${version.SEMVER_INCREMENTS.join(
+							', '
+						)}, or a valid semver version.`
+					);
 				}
 
 				newVersion = version(pkg.version).getNewVersionFrom(input);
 				if (version(pkg.version).isLowerThanOrEqualTo(newVersion)) {
-					throw new Error(`New version \`${newVersion}\` should be higher than current version \`${pkg.version}\``);
+					throw new Error(
+						`New version \`${newVersion}\` should be higher than current version \`${pkg.version}\``
+					);
 				}
 			}
 		},
 		{
 			title: 'Check for pre-release version',
 			task: () => {
-				if (!pkg.private && version(newVersion).isPrerelease() && !options.tag) {
-					throw new Error('You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag');
+				if (
+					!pkg.private &&
+					version(newVersion).isPrerelease() &&
+					!options.tag
+				) {
+					throw new Error(
+						'You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag'
+					);
 				}
 			}
 		},

--- a/source/pretty-version-diff.js
+++ b/source/pretty-version-diff.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import version from './version';
+import version from './version.js';
 
 const prettyVersionDiff = (oldVersion, inc) => {
 	const newVersion = version(oldVersion).getNewVersionFrom(inc).split('.');
@@ -7,7 +7,7 @@ const prettyVersionDiff = (oldVersion, inc) => {
 	let firstVersionChange = false;
 	const output = [];
 	for (const [i, element] of newVersion.entries()) {
-		if ((element !== oldVersion[i] && !firstVersionChange)) {
+		if (element !== oldVersion[i] && !firstVersionChange) {
 			output.push(`${chalk.dim.cyan(element)}`);
 			firstVersionChange = true;
 		} else if (element.indexOf('-') >= 1) {

--- a/source/pretty-version-diff.js
+++ b/source/pretty-version-diff.js
@@ -1,13 +1,11 @@
-'use strict';
-const chalk = require('chalk');
-const version = require('./version');
+import chalk from 'chalk';
+import version from './version';
 
-module.exports = (oldVersion, inc) => {
+const prettyVersionDiff = (oldVersion, inc) => {
 	const newVersion = version(oldVersion).getNewVersionFrom(inc).split('.');
 	oldVersion = oldVersion.split('.');
 	let firstVersionChange = false;
 	const output = [];
-
 	for (const [i, element] of newVersion.entries()) {
 		if ((element !== oldVersion[i] && !firstVersionChange)) {
 			output.push(`${chalk.dim.cyan(element)}`);
@@ -23,3 +21,5 @@ module.exports = (oldVersion, inc) => {
 
 	return output.join(chalk.reset.dim('.'));
 };
+
+export default prettyVersionDiff;

--- a/source/release-task-helper.js
+++ b/source/release-task-helper.js
@@ -1,11 +1,11 @@
 import open from 'open';
 import newGithubReleaseUrl from 'new-github-release-url';
-import {getTagVersionPrefix, getPreReleasePrefix} from './util';
-import version from './version';
+import {getTagVersionPrefix, getPreReleasePrefix} from './util.js';
+import version from './version.js';
 
 const releaseTaskHelper = async (options, pkg) => {
 	const newVersion = version(pkg.version).getNewVersionFrom(options.version);
-	let tag = await getTagVersionPrefix(options) + newVersion;
+	let tag = (await getTagVersionPrefix(options)) + newVersion;
 	const isPreRelease = version(options.version).isPrerelease();
 	if (isPreRelease) {
 		tag += await getPreReleasePrefix(options);

--- a/source/release-task-helper.js
+++ b/source/release-task-helper.js
@@ -1,10 +1,9 @@
-'use strict';
-const open = require('open');
-const newGithubReleaseUrl = require('new-github-release-url');
-const {getTagVersionPrefix, getPreReleasePrefix} = require('./util');
-const version = require('./version');
+import open from 'open';
+import newGithubReleaseUrl from 'new-github-release-url';
+import {getTagVersionPrefix, getPreReleasePrefix} from './util';
+import version from './version';
 
-module.exports = async (options, pkg) => {
+const releaseTaskHelper = async (options, pkg) => {
 	const newVersion = version(pkg.version).getNewVersionFrom(options.version);
 	let tag = await getTagVersionPrefix(options) + newVersion;
 	const isPreRelease = version(options.version).isPrerelease();
@@ -18,6 +17,7 @@ module.exports = async (options, pkg) => {
 		body: options.releaseNotes(tag),
 		isPrerelease: isPreRelease
 	});
-
 	await open(url);
 };
+
+export default releaseTaskHelper;

--- a/source/util.js
+++ b/source/util.js
@@ -1,17 +1,16 @@
-'use strict';
-const readPkgUp = require('read-pkg-up');
-const issueRegex = require('issue-regex');
-const terminalLink = require('terminal-link');
-const execa = require('execa');
-const pMemoize = require('p-memoize');
-const {default: ow} = require('ow');
-const pkgDir = require('pkg-dir');
-const gitUtil = require('./git-util');
-const npmUtil = require('./npm/util');
+import readPkgUp from 'read-pkg-up';
+import issueRegex from 'issue-regex';
+import terminalLink from 'terminal-link';
+import execa from 'execa';
+import pMemoize from 'p-memoize';
+import ow$0 from 'ow';
+import pkgDir from 'pkg-dir';
+import * as gitUtil from './git-util';
+import * as npmUtil from './npm/util';
 
-exports.readPkg = packagePath => {
+const {default: ow} = ow$0;
+export const readPkg = packagePath => {
 	packagePath = packagePath ? pkgDir.sync(packagePath) : pkgDir.sync();
-
 	if (!packagePath) {
 		throw new Error('No `package.json` found. Make sure the current directory is a valid package.');
 	}
@@ -19,18 +18,16 @@ exports.readPkg = packagePath => {
 	const {packageJson} = readPkgUp.sync({
 		cwd: packagePath
 	});
-
 	return packageJson;
 };
 
-exports.linkifyIssues = (url, message) => {
+export const linkifyIssues = (url, message) => {
 	if (!(url && terminalLink.isSupported)) {
 		return message;
 	}
 
 	return message.replace(issueRegex(), issue => {
 		const issuePart = issue.replace('#', '/issues/');
-
 		if (issue.startsWith('#')) {
 			return terminalLink(issue, `${url}${issuePart}`);
 		}
@@ -39,7 +36,7 @@ exports.linkifyIssues = (url, message) => {
 	});
 };
 
-exports.linkifyCommit = (url, commit) => {
+export const linkifyCommit = (url, commit) => {
 	if (!(url && terminalLink.isSupported)) {
 		return commit;
 	}
@@ -47,7 +44,7 @@ exports.linkifyCommit = (url, commit) => {
 	return terminalLink(commit, `${url}/commit/${commit}`);
 };
 
-exports.linkifyCommitRange = (url, commitRange) => {
+export const linkifyCommitRange = (url, commitRange) => {
 	if (!(url && terminalLink.isSupported)) {
 		return commitRange;
 	}
@@ -55,9 +52,8 @@ exports.linkifyCommitRange = (url, commitRange) => {
 	return terminalLink(commitRange, `${url}/compare/${commitRange}`);
 };
 
-exports.getTagVersionPrefix = pMemoize(async options => {
+export const getTagVersionPrefix = pMemoize(async options => {
 	ow(options, ow.object.hasKeys('yarn'));
-
 	try {
 		if (options.yarn) {
 			const {stdout} = await execa('yarn', ['config', 'get', 'version-tag-prefix']);
@@ -70,15 +66,13 @@ exports.getTagVersionPrefix = pMemoize(async options => {
 		return 'v';
 	}
 });
-
-exports.getNewFiles = async pkg => {
+export const getNewFiles = async pkg => {
 	const listNewFiles = await gitUtil.newFilesSinceLastRelease();
 	return {unpublished: await npmUtil.getNewAndUnpublishedFiles(pkg, listNewFiles), firstTime: await npmUtil.getFirstTimePublishedFiles(pkg, listNewFiles)};
 };
 
-exports.getPreReleasePrefix = pMemoize(async options => {
+export const getPreReleasePrefix = pMemoize(async options => {
 	ow(options, ow.object.hasKeys('yarn'));
-
 	try {
 		if (options.yarn) {
 			const {stdout} = await execa('yarn', ['config', 'get', 'preId']);

--- a/source/util.js
+++ b/source/util.js
@@ -5,14 +5,16 @@ import execa from 'execa';
 import pMemoize from 'p-memoize';
 import ow$0 from 'ow';
 import pkgDir from 'pkg-dir';
-import * as gitUtil from './git-util';
-import * as npmUtil from './npm/util';
+import * as gitUtil from './git-util.js';
+import * as npmUtil from './npm/util.js';
 
 const {default: ow} = ow$0;
 export const readPkg = packagePath => {
 	packagePath = packagePath ? pkgDir.sync(packagePath) : pkgDir.sync();
 	if (!packagePath) {
-		throw new Error('No `package.json` found. Make sure the current directory is a valid package.');
+		throw new Error(
+			'No `package.json` found. Make sure the current directory is a valid package.'
+		);
 	}
 
 	const {packageJson} = readPkgUp.sync({
@@ -56,11 +58,19 @@ export const getTagVersionPrefix = pMemoize(async options => {
 	ow(options, ow.object.hasKeys('yarn'));
 	try {
 		if (options.yarn) {
-			const {stdout} = await execa('yarn', ['config', 'get', 'version-tag-prefix']);
+			const {stdout} = await execa('yarn', [
+				'config',
+				'get',
+				'version-tag-prefix'
+			]);
 			return stdout;
 		}
 
-		const {stdout} = await execa('npm', ['config', 'get', 'tag-version-prefix']);
+		const {stdout} = await execa('npm', [
+			'config',
+			'get',
+			'tag-version-prefix'
+		]);
 		return stdout;
 	} catch {
 		return 'v';
@@ -68,7 +78,10 @@ export const getTagVersionPrefix = pMemoize(async options => {
 });
 export const getNewFiles = async pkg => {
 	const listNewFiles = await gitUtil.newFilesSinceLastRelease();
-	return {unpublished: await npmUtil.getNewAndUnpublishedFiles(pkg, listNewFiles), firstTime: await npmUtil.getFirstTimePublishedFiles(pkg, listNewFiles)};
+	return {
+		unpublished: await npmUtil.getNewAndUnpublishedFiles(pkg, listNewFiles),
+		firstTime: await npmUtil.getFirstTimePublishedFiles(pkg, listNewFiles)
+	};
 };
 
 export const getPreReleasePrefix = pMemoize(async options => {

--- a/source/version.js
+++ b/source/version.js
@@ -1,5 +1,5 @@
-'use strict';
-const semver = require('semver');
+import * as semver from 'semver';
+import package$0 from '../package.json';
 
 class Version {
 	constructor(version) {
@@ -29,38 +29,33 @@ class Version {
 	isGreaterThanOrEqualTo(otherVersion) {
 		module.exports.validate(this.version);
 		module.exports.validate(otherVersion);
-
 		return semver.gte(otherVersion, this.version);
 	}
 
 	isLowerThanOrEqualTo(otherVersion) {
 		module.exports.validate(this.version);
 		module.exports.validate(otherVersion);
-
 		return semver.lte(otherVersion, this.version);
 	}
 }
-
-module.exports = version => new Version(version);
-
-module.exports.SEMVER_INCREMENTS = ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease'];
-module.exports.PRERELEASE_VERSIONS = ['prepatch', 'preminor', 'premajor', 'prerelease'];
-
-module.exports.isPrereleaseOrIncrement = input => module.exports(input).isPrerelease() || module.exports.PRERELEASE_VERSIONS.includes(input);
-
 const isValidVersion = input => Boolean(semver.valid(input));
-
-module.exports.isValidInput = input => module.exports.SEMVER_INCREMENTS.includes(input) || isValidVersion(input);
-
-module.exports.validate = version => {
+export const SEMVER_INCREMENTS = ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease'];
+export const PRERELEASE_VERSIONS = ['prepatch', 'preminor', 'premajor', 'prerelease'];
+export const isPrereleaseOrIncrement = input => module.exports(input).isPrerelease() || module.exports.PRERELEASE_VERSIONS.includes(input);
+export const isValidInput = input => module.exports.SEMVER_INCREMENTS.includes(input) || isValidVersion(input);
+export const validate = version => {
 	if (!isValidVersion(version)) {
 		throw new Error('Version should be a valid semver version.');
 	}
 };
 
-module.exports.verifyRequirementSatisfied = (dependency, version) => {
-	const depRange = require('../package.json').engines[dependency];
+export const verifyRequirementSatisfied = (dependency, version) => {
+	const depRange = package$0.engines[dependency];
 	if (!module.exports(version).satisfies(depRange)) {
 		throw new Error(`Please upgrade to ${dependency}${depRange}`);
 	}
 };
+
+const version = version => new Version(version);
+
+export default version;

--- a/source/version.js
+++ b/source/version.js
@@ -1,48 +1,27 @@
 import * as semver from 'semver';
 import package$0 from '../package.json';
 
-class Version {
-	constructor(version) {
-		this.version = version;
-	}
-
-	isPrerelease() {
-		return Boolean(semver.prerelease(this.version));
-	}
-
-	satisfies(range) {
-		module.exports.validate(this.version);
-		return semver.satisfies(this.version, range, {
-			includePrerelease: true
-		});
-	}
-
-	getNewVersionFrom(input) {
-		module.exports.validate(this.version);
-		if (!module.exports.isValidInput(input)) {
-			throw new Error(`Version should be either ${module.exports.SEMVER_INCREMENTS.join(', ')} or a valid semver version.`);
-		}
-
-		return module.exports.SEMVER_INCREMENTS.includes(input) ? semver.inc(this.version, input) : input;
-	}
-
-	isGreaterThanOrEqualTo(otherVersion) {
-		module.exports.validate(this.version);
-		module.exports.validate(otherVersion);
-		return semver.gte(otherVersion, this.version);
-	}
-
-	isLowerThanOrEqualTo(otherVersion) {
-		module.exports.validate(this.version);
-		module.exports.validate(otherVersion);
-		return semver.lte(otherVersion, this.version);
-	}
-}
 const isValidVersion = input => Boolean(semver.valid(input));
-export const SEMVER_INCREMENTS = ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease'];
-export const PRERELEASE_VERSIONS = ['prepatch', 'preminor', 'premajor', 'prerelease'];
-export const isPrereleaseOrIncrement = input => module.exports(input).isPrerelease() || module.exports.PRERELEASE_VERSIONS.includes(input);
-export const isValidInput = input => module.exports.SEMVER_INCREMENTS.includes(input) || isValidVersion(input);
+export const SEMVER_INCREMENTS = [
+	'patch',
+	'minor',
+	'major',
+	'prepatch',
+	'preminor',
+	'premajor',
+	'prerelease'
+];
+export const PRERELEASE_VERSIONS = [
+	'prepatch',
+	'preminor',
+	'premajor',
+	'prerelease'
+];
+export const isPrereleaseOrIncrement = input =>
+	module.exports(input).isPrerelease() ||
+	module.exports.PRERELEASE_VERSIONS.includes(input);
+export const isValidInput = input =>
+	module.exports.SEMVER_INCREMENTS.includes(input) || isValidVersion(input);
 export const validate = version => {
 	if (!isValidVersion(version)) {
 		throw new Error('Version should be a valid semver version.');
@@ -57,5 +36,49 @@ export const verifyRequirementSatisfied = (dependency, version) => {
 };
 
 const version = version => new Version(version);
+
+class Version {
+	constructor(version) {
+		this.version = version;
+	}
+
+	isPrerelease() {
+		return Boolean(semver.prerelease(this.version));
+	}
+
+	satisfies(range) {
+		validate(this.version);
+		return semver.satisfies(this.version, range, {
+			includePrerelease: true
+		});
+	}
+
+	getNewVersionFrom(input) {
+		validate(this.version);
+		if (!module.exports.isValidInput(input)) {
+			throw new Error(
+				`Version should be either ${module.exports.SEMVER_INCREMENTS.join(
+					', '
+				)} or a valid semver version.`
+			);
+		}
+
+		return module.exports.SEMVER_INCREMENTS.includes(input) ?
+			semver.inc(this.version, input) :
+			input;
+	}
+
+	isGreaterThanOrEqualTo(otherVersion) {
+		validate(this.version);
+		validate(otherVersion);
+		return semver.gte(otherVersion, this.version);
+	}
+
+	isLowerThanOrEqualTo(otherVersion) {
+		validate(this.version);
+		validate(otherVersion);
+		return semver.lte(otherVersion, this.version);
+	}
+}
 
 export default version;

--- a/test/fixtures/listr-renderer.js
+++ b/test/fixtures/listr-renderer.js
@@ -1,6 +1,6 @@
 let tasks;
 
-class SilentRenderer {
+export class SilentRenderer {
 	constructor(_tasks) {
 		tasks = _tasks;
 	}
@@ -17,5 +17,3 @@ class SilentRenderer {
 
 	end() { }
 }
-
-module.exports.SilentRenderer = SilentRenderer;

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import execaStub from 'execa_test_double';
 import mockery from 'mockery';
-import {SilentRenderer} from './fixtures/listr-renderer';
+import {SilentRenderer} from './fixtures/listr-renderer.js';
 
 let testedModule;
 
@@ -10,67 +10,90 @@ const run = async listr => {
 	await listr.run();
 };
 
-test.before(() => {
+test.before(async () => {
 	mockery.registerMock('execa', execaStub.execa);
 	mockery.enable({
 		useCleanCache: true,
 		warnOnReplace: false,
 		warnOnUnregistered: false
 	});
-	testedModule = require('../source/git-tasks');
+	testedModule = await import('../source/git-tasks.js');
 });
 
 test.beforeEach(() => {
 	execaStub.resetStub();
 });
 
-test.serial('should fail when release branch is not specified, current branch is not the release branch, and publishing from any branch not permitted', async t => {
-	execaStub.createStub([
-		{
-			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
-			stdout: 'feature'
-		}
-	]);
-	await t.throwsAsync(run(testedModule({branch: 'master'})),
-		{message: 'Not on `master` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
-});
+test.serial(
+	'should fail when release branch is not specified, current branch is not the release branch, and publishing from any branch not permitted',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git symbolic-ref --short HEAD',
+				exitCode: 0,
+				stdout: 'feature'
+			}
+		]);
+		await t.throwsAsync(run(testedModule({branch: 'master'})), {
+			message:
+				'Not on `master` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.'
+		});
+		t.true(
+			SilentRenderer.tasks.some(
+				task => task.title === 'Check current branch' && task.hasFailed()
+			)
+		);
+	}
+);
 
-test.serial('should fail when current branch is not the specified release branch and publishing from any branch not permitted', async t => {
-	execaStub.createStub([
-		{
-			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
-			stdout: 'feature'
-		}
-	]);
-	await t.throwsAsync(run(testedModule({branch: 'release'})),
-		{message: 'Not on `release` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check current branch' && task.hasFailed()));
-});
+test.serial(
+	'should fail when current branch is not the specified release branch and publishing from any branch not permitted',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git symbolic-ref --short HEAD',
+				exitCode: 0,
+				stdout: 'feature'
+			}
+		]);
+		await t.throwsAsync(run(testedModule({branch: 'release'})), {
+			message:
+				'Not on `release` branch. Use --any-branch to publish anyway, or set a different release branch using --branch.'
+		});
+		t.true(
+			SilentRenderer.tasks.some(
+				task => task.title === 'Check current branch' && task.hasFailed()
+			)
+		);
+	}
+);
 
-test.serial('should not fail when current branch not master and publishing from any branch permitted', async t => {
-	execaStub.createStub([
-		{
-			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
-			stdout: 'feature'
-		},
-		{
-			command: 'git status --porcelain',
-			exitCode: 0,
-			stdout: ''
-		},
-		{
-			command: 'git rev-list --count --left-only @{u}...HEAD',
-			exitCode: 0,
-			stdout: ''
-		}
-	]);
-	await run(testedModule({anyBranch: true}));
-	t.false(SilentRenderer.tasks.some(task => task.title === 'Check current branch'));
-});
+test.serial(
+	'should not fail when current branch not master and publishing from any branch permitted',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git symbolic-ref --short HEAD',
+				exitCode: 0,
+				stdout: 'feature'
+			},
+			{
+				command: 'git status --porcelain',
+				exitCode: 0,
+				stdout: ''
+			},
+			{
+				command: 'git rev-list --count --left-only @{u}...HEAD',
+				exitCode: 0,
+				stdout: ''
+			}
+		]);
+		await run(testedModule({anyBranch: true}));
+		t.false(
+			SilentRenderer.tasks.some(task => task.title === 'Check current branch')
+		);
+	}
+);
 
 test.serial('should fail when local working tree modified', async t => {
 	execaStub.createStub([
@@ -85,8 +108,14 @@ test.serial('should fail when local working tree modified', async t => {
 			stdout: 'M source/git-tasks.js'
 		}
 	]);
-	await t.throwsAsync(run(testedModule({branch: 'master'})), {message: 'Unclean working tree. Commit or stash changes first.'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check local working tree' && task.hasFailed()));
+	await t.throwsAsync(run(testedModule({branch: 'master'})), {
+		message: 'Unclean working tree. Commit or stash changes first.'
+	});
+	t.true(
+		SilentRenderer.tasks.some(
+			task => task.title === 'Check local working tree' && task.hasFailed()
+		)
+	);
 });
 
 test.serial('should fail when remote history differs', async t => {
@@ -107,27 +136,36 @@ test.serial('should fail when remote history differs', async t => {
 			stdout: '1'
 		}
 	]);
-	await t.throwsAsync(run(testedModule({branch: 'master'})), {message: 'Remote history differs. Please pull changes.'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check remote history' && task.hasFailed()));
+	await t.throwsAsync(run(testedModule({branch: 'master'})), {
+		message: 'Remote history differs. Please pull changes.'
+	});
+	t.true(
+		SilentRenderer.tasks.some(
+			task => task.title === 'Check remote history' && task.hasFailed()
+		)
+	);
 });
 
-test.serial('checks should pass when publishing from master, working tree is clean and remote history not different', async t => {
-	execaStub.createStub([
-		{
-			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
-			stdout: 'master'
-		},
-		{
-			command: 'git status --porcelain',
-			exitCode: 0,
-			stdout: ''
-		},
-		{
-			command: 'git rev-list --count --left-only @{u}...HEAD',
-			exitCode: 0,
-			stdout: ''
-		}
-	]);
-	await t.notThrowsAsync(run(testedModule({branch: 'master'})));
-});
+test.serial(
+	'checks should pass when publishing from master, working tree is clean and remote history not different',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git symbolic-ref --short HEAD',
+				exitCode: 0,
+				stdout: 'master'
+			},
+			{
+				command: 'git status --porcelain',
+				exitCode: 0,
+				stdout: ''
+			},
+			{
+				command: 'git rev-list --count --left-only @{u}...HEAD',
+				exitCode: 0,
+				stdout: ''
+			}
+		]);
+		await t.notThrowsAsync(run(testedModule({branch: 'master'})));
+	}
+);

--- a/test/hyperlinks.js
+++ b/test/hyperlinks.js
@@ -1,7 +1,11 @@
 import test from 'ava';
 import sinon from 'sinon';
 import terminalLink from 'terminal-link';
-import {linkifyIssues, linkifyCommit, linkifyCommitRange} from '../source/util';
+import {
+	linkifyIssues,
+	linkifyCommit,
+	linkifyCommitRange
+} from '../source/util.js';
 
 const MOCK_REPO_URL = 'https://github.com/unicorn/rainbow';
 const MOCK_COMMIT_HASH = '5063f8a';
@@ -17,9 +21,18 @@ const mockTerminalLinkUnsupported = () =>
 	sandbox.stub(terminalLink, 'isSupported').value(false);
 
 test('linkifyIssues correctly links issues', t => {
-	t.is(linkifyIssues(MOCK_REPO_URL, 'Commit message - fixes #4'), 'Commit message - fixes ]8;;https://github.com/unicorn/rainbow/issues/4#4]8;;');
-	t.is(linkifyIssues(MOCK_REPO_URL, 'Commit message - fixes #3 #4'), 'Commit message - fixes ]8;;https://github.com/unicorn/rainbow/issues/3#3]8;; ]8;;https://github.com/unicorn/rainbow/issues/4#4]8;;');
-	t.is(linkifyIssues(MOCK_REPO_URL, 'Commit message - fixes foo/bar#4'), 'Commit message - fixes ]8;;https://github.com/foo/bar/issues/4foo/bar#4]8;;');
+	t.is(
+		linkifyIssues(MOCK_REPO_URL, 'Commit message - fixes #4'),
+		'Commit message - fixes ]8;;https://github.com/unicorn/rainbow/issues/4#4]8;;'
+	);
+	t.is(
+		linkifyIssues(MOCK_REPO_URL, 'Commit message - fixes #3 #4'),
+		'Commit message - fixes ]8;;https://github.com/unicorn/rainbow/issues/3#3]8;; ]8;;https://github.com/unicorn/rainbow/issues/4#4]8;;'
+	);
+	t.is(
+		linkifyIssues(MOCK_REPO_URL, 'Commit message - fixes foo/bar#4'),
+		'Commit message - fixes ]8;;https://github.com/foo/bar/issues/4foo/bar#4]8;;'
+	);
 });
 
 test('linkifyIssues returns raw message if url is not provided', t => {
@@ -27,11 +40,14 @@ test('linkifyIssues returns raw message if url is not provided', t => {
 	t.is(linkifyIssues(undefined, message), message);
 });
 
-test.serial('linkifyIssues returns raw message if terminalLink is not supported', t => {
-	mockTerminalLinkUnsupported();
-	const message = 'Commit message - fixes #6';
-	t.is(linkifyIssues(MOCK_REPO_URL, message), message);
-});
+test.serial(
+	'linkifyIssues returns raw message if terminalLink is not supported',
+	t => {
+		mockTerminalLinkUnsupported();
+		const message = 'Commit message - fixes #6';
+		t.is(linkifyIssues(MOCK_REPO_URL, message), message);
+	}
+);
 
 test('linkifyCommit correctly links commits', t => {
 	t.is(linkifyCommit(MOCK_REPO_URL, MOCK_COMMIT_HASH), ']8;;https://github.com/unicorn/rainbow/commit/5063f8a5063f8a]8;;');
@@ -41,16 +57,25 @@ test('linkifyCommit returns raw commit hash if url is not provided', t => {
 	t.is(linkifyCommit(undefined, MOCK_COMMIT_HASH), MOCK_COMMIT_HASH);
 });
 
-test.serial('linkifyCommit returns raw commit hash if terminalLink is not supported', t => {
-	mockTerminalLinkUnsupported();
-	t.is(linkifyCommit(MOCK_REPO_URL, MOCK_COMMIT_HASH), MOCK_COMMIT_HASH);
-});
+test.serial(
+	'linkifyCommit returns raw commit hash if terminalLink is not supported',
+	t => {
+		mockTerminalLinkUnsupported();
+		t.is(linkifyCommit(MOCK_REPO_URL, MOCK_COMMIT_HASH), MOCK_COMMIT_HASH);
+	}
+);
 
 test('linkifyCommitRange returns raw commitRange if url is not provided', t => {
 	t.is(linkifyCommitRange(undefined, MOCK_COMMIT_RANGE), MOCK_COMMIT_RANGE);
 });
 
-test.serial('linkifyCommitRange returns raw commitRange if terminalLink is not supported', t => {
-	mockTerminalLinkUnsupported();
-	t.is(linkifyCommitRange(MOCK_REPO_URL, MOCK_COMMIT_RANGE), MOCK_COMMIT_RANGE);
-});
+test.serial(
+	'linkifyCommitRange returns raw commitRange if terminalLink is not supported',
+	t => {
+		mockTerminalLinkUnsupported();
+		t.is(
+			linkifyCommitRange(MOCK_REPO_URL, MOCK_COMMIT_RANGE),
+			MOCK_COMMIT_RANGE
+		);
+	}
+);

--- a/test/index.js
+++ b/test/index.js
@@ -15,13 +15,15 @@ const defaultOptions = {
 };
 
 test('version is invalid', async t => {
-	const message = 'Version should be either patch, minor, major, prepatch, preminor, premajor, prerelease, or a valid semver version.';
+	const message =
+		'Version should be either patch, minor, major, prepatch, preminor, premajor, prerelease, or a valid semver version.';
 	await t.throwsAsync(np('foo', defaultOptions), message);
 	await t.throwsAsync(np('4.x.3', defaultOptions), message);
 });
 
 test('version is pre-release', async t => {
-	const message = 'You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag';
+	const message =
+		'You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag';
 	await t.throwsAsync(np('premajor', defaultOptions), message);
 	await t.throwsAsync(np('preminor', defaultOptions), message);
 	await t.throwsAsync(np('prepatch', defaultOptions), message);
@@ -31,8 +33,14 @@ test('version is pre-release', async t => {
 });
 
 test('errors on too low version', async t => {
-	await t.throwsAsync(np('1.0.0', defaultOptions), /New version `1\.0\.0` should be higher than current version `\d+\.\d+\.\d+`/);
-	await t.throwsAsync(np('1.0.0-beta', defaultOptions), /New version `1\.0\.0-beta` should be higher than current version `\d+\.\d+\.\d+`/);
+	await t.throwsAsync(
+		np('1.0.0', defaultOptions),
+		/New version `1\.0\.0` should be higher than current version `\d+\.\d+\.\d+`/
+	);
+	await t.throwsAsync(
+		np('1.0.0-beta', defaultOptions),
+		/New version `1\.0\.0-beta` should be higher than current version `\d+\.\d+\.\d+`/
+	);
 });
 
 test('skip enabling 2FA if the package exists', async t => {
@@ -51,13 +59,15 @@ test('skip enabling 2FA if the package exists', async t => {
 		'./npm/publish': sinon.stub().returns({pipe: sinon.stub()})
 	});
 
-	await t.notThrowsAsync(np('1.0.0', {
-		...defaultOptions,
-		availability: {
-			isAvailable: false,
-			isUnknown: false
-		}
-	}));
+	await t.notThrowsAsync(
+		np('1.0.0', {
+			...defaultOptions,
+			availability: {
+				isAvailable: false,
+				isUnknown: false
+			}
+		})
+	);
 
 	t.true(enable2faStub.notCalled);
 });
@@ -78,14 +88,16 @@ test('skip enabling 2FA if the `2fa` option is false', async t => {
 		'./npm/publish': sinon.stub().returns({pipe: sinon.stub()})
 	});
 
-	await t.notThrowsAsync(np('1.0.0', {
-		...defaultOptions,
-		availability: {
-			isAvailable: true,
-			isUnknown: false
-		},
-		'2fa': false
-	}));
+	await t.notThrowsAsync(
+		np('1.0.0', {
+			...defaultOptions,
+			availability: {
+				isAvailable: true,
+				isUnknown: false
+			},
+			'2fa': false
+		})
+	);
 
 	t.true(enable2faStub.notCalled);
 });

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,5 +1,5 @@
-const test = require('ava');
-const execa = require('execa');
+import test from 'ava';
+import execa from 'execa';
 
 test.after.always(async () => {
 	await execa('git', ['submodule', 'update', '--remote']);

--- a/test/npmignore.js
+++ b/test/npmignore.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import test from 'ava';
 import proxyquire from 'proxyquire';
+import {createRequire} from 'module';
 
 const newFiles = [
 	'source/ignore.txt',
@@ -13,142 +14,216 @@ const newFiles = [
 
 test('ignored files using file-attribute in package.json with one file', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'package')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'package')
+		}
 	});
-	t.deepEqual(await testedModule.getNewAndUnpublishedFiles({files: ['pay_attention.txt']}, newFiles), ['source/ignore.txt']);
+	t.deepEqual(
+		await testedModule.getNewAndUnpublishedFiles(
+			{files: ['pay_attention.txt']},
+			newFiles
+		),
+		['source/ignore.txt']
+	);
 });
 
 test('ignored file using file-attribute in package.json with directory', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'package')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'package')
+		}
 	});
-	t.deepEqual(await testedModule.getNewAndUnpublishedFiles({files: ['source']}, newFiles), []);
+	t.deepEqual(
+		await testedModule.getNewAndUnpublishedFiles(
+			{files: ['source']},
+			newFiles
+		),
+		[]
+	);
 });
 
 test('ignored test files using files attribute and directory structure in package.json', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'package')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'package')
+		}
 	});
-	t.deepEqual(await testedModule.getNewAndUnpublishedFiles({files: ['source'], directories: {test: 'test-tap'}}, newFiles), ['test/file.txt']);
-	t.deepEqual(await testedModule.getNewAndUnpublishedFiles({files: ['source'], directories: {test: ['test-tap']}}, newFiles), ['test/file.txt']);
+	t.deepEqual(
+		await testedModule.getNewAndUnpublishedFiles(
+			{files: ['source'], directories: {test: 'test-tap'}},
+			newFiles
+		),
+		['test/file.txt']
+	);
+	t.deepEqual(
+		await testedModule.getNewAndUnpublishedFiles(
+			{files: ['source'], directories: {test: ['test-tap']}},
+			newFiles
+		),
+		['test/file.txt']
+	);
 });
 
 test('ignored files using .npmignore', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'npmignore')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'npmignore')
+		}
 	});
-	t.deepEqual(await testedModule.getNewAndUnpublishedFiles({name: 'npmignore'}, newFiles), ['source/ignore.txt']);
+	t.deepEqual(
+		await testedModule.getNewAndUnpublishedFiles(
+			{name: 'npmignore'},
+			newFiles
+		),
+		['source/ignore.txt']
+	);
 });
 
 test('ignored test files using files attribute and .npmignore', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'npmignore')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'npmignore')
+		}
 	});
-	t.deepEqual(await testedModule.getNewAndUnpublishedFiles({directories: {test: 'test-tap'}}, newFiles), ['source/ignore.txt', 'test/file.txt']);
-	t.deepEqual(await testedModule.getNewAndUnpublishedFiles({directories: {test: ['test-tap']}}, newFiles), ['source/ignore.txt', 'test/file.txt']);
+	t.deepEqual(
+		await testedModule.getNewAndUnpublishedFiles(
+			{directories: {test: 'test-tap'}},
+			newFiles
+		),
+		['source/ignore.txt', 'test/file.txt']
+	);
+	t.deepEqual(
+		await testedModule.getNewAndUnpublishedFiles(
+			{directories: {test: ['test-tap']}},
+			newFiles
+		),
+		['source/ignore.txt', 'test/file.txt']
+	);
 });
 
 test('ignored files - dot files using files attribute', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'package')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'package')
+		}
 	});
-	t.deepEqual(await testedModule.getNewAndUnpublishedFiles({files: ['source']}, ['test/.dotfile']), []);
+	t.deepEqual(
+		await testedModule.getNewAndUnpublishedFiles({files: ['source']}, [
+			'test/.dotfile'
+		]),
+		[]
+	);
 });
 
 test('ignored files - dot files using .npmignore', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'npmignore')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'npmignore')
+		}
 	});
-	t.deepEqual(await testedModule.getNewAndUnpublishedFiles({}, ['test/.dot']), []);
+	t.deepEqual(
+		await testedModule.getNewAndUnpublishedFiles({}, ['test/.dot']),
+		[]
+	);
 });
 
 test('ignored files - ignore strategy is not used', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures')
+		}
 	});
-	t.is(await testedModule.getNewAndUnpublishedFiles({name: 'no ignore strategy'}, newFiles), undefined);
+	t.is(
+		await testedModule.getNewAndUnpublishedFiles(
+			{name: 'no ignore strategy'},
+			newFiles
+		),
+		undefined
+	);
 });
 
 test('first time published files using file-attribute in package.json with one file', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'package')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'package')
+		}
 	});
-	t.deepEqual(await testedModule.getFirstTimePublishedFiles({files: ['pay_attention.txt']}, newFiles), ['source/pay_attention.txt']);
+	t.deepEqual(
+		await testedModule.getFirstTimePublishedFiles(
+			{files: ['pay_attention.txt']},
+			newFiles
+		),
+		['source/pay_attention.txt']
+	);
 });
 
 test('first time published files using file-attribute in package.json with directory', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'package')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'package')
+		}
 	});
-	t.deepEqual(await testedModule.getFirstTimePublishedFiles({files: ['source']}, newFiles), ['source/ignore.txt', 'source/pay_attention.txt']);
+	t.deepEqual(
+		await testedModule.getFirstTimePublishedFiles(
+			{files: ['source']},
+			newFiles
+		),
+		['source/ignore.txt', 'source/pay_attention.txt']
+	);
 });
 
 test('first time published files using .npmignore', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'npmignore')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'npmignore')
+		}
 	});
-	t.deepEqual(await testedModule.getFirstTimePublishedFiles({name: 'npmignore'}, newFiles), ['source/pay_attention.txt']);
+	t.deepEqual(
+		await testedModule.getFirstTimePublishedFiles(
+			{name: 'npmignore'},
+			newFiles
+		),
+		['source/pay_attention.txt']
+	);
 });
 
 test('first time published dot files using files attribute', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'package')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'package')
+		}
 	});
-	t.deepEqual(await testedModule.getFirstTimePublishedFiles({files: ['source']}, ['source/.dotfile']), ['source/.dotfile']);
+	t.deepEqual(
+		await testedModule.getFirstTimePublishedFiles({files: ['source']}, [
+			'source/.dotfile'
+		]),
+		['source/.dotfile']
+	);
 });
 
 test('first time published dot files using .npmignore', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures', 'npmignore')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures', 'npmignore')
+		}
 	});
-	t.deepEqual(await testedModule.getFirstTimePublishedFiles({}, ['source/.dotfile']), ['source/.dotfile']);
+	t.deepEqual(
+		await testedModule.getFirstTimePublishedFiles({}, ['source/.dotfile']),
+		['source/.dotfile']
+	);
 });
 
 test('first time published files - ignore strategy is not used', async t => {
 	const testedModule = proxyquire('../source/npm/util', {
-		'pkg-dir':
-			{
-				sync: () => path.resolve('test', 'fixtures')
-			}
+		'pkg-dir': {
+			sync: () => path.resolve('test', 'fixtures')
+		}
 	});
-	t.deepEqual(await testedModule.getFirstTimePublishedFiles({name: 'no ignore strategy'}, newFiles), ['source/ignore.txt', 'source/pay_attention.txt', 'test/file.txt']);
+	t.deepEqual(
+		await testedModule.getFirstTimePublishedFiles(
+			{name: 'no ignore strategy'},
+			newFiles
+		),
+		['source/ignore.txt', 'source/pay_attention.txt', 'test/file.txt']
+	);
 });

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import proxyquire from 'proxyquire';
-import {getTagVersionPrefix} from '../source/util';
+import {getTagVersionPrefix} from '../source/util.js';
 
 test('get tag prefix', async t => {
 	t.is(await getTagVersionPrefix({yarn: false}), 'v');
@@ -8,8 +8,13 @@ test('get tag prefix', async t => {
 });
 
 test('no options passed', async t => {
-	await t.throwsAsync(getTagVersionPrefix(), {message: 'Expected `options` to be of type `object` but received type `undefined`'});
-	await t.throwsAsync(getTagVersionPrefix({}), {message: 'Expected object `options` to have keys `["yarn"]`'});
+	await t.throwsAsync(getTagVersionPrefix(), {
+		message:
+			'Expected `options` to be of type `object` but received type `undefined`'
+	});
+	await t.throwsAsync(getTagVersionPrefix({}), {
+		message: 'Expected object `options` to have keys `["yarn"]`'
+	});
 });
 
 test.serial('defaults to "v" when command fails', async t => {

--- a/test/preid.js
+++ b/test/preid.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {getPreReleasePrefix} from '../source/util';
+import {getPreReleasePrefix} from '../source/util.js';
 
 test('get preId postfix', async t => {
 	t.is(await getPreReleasePrefix({yarn: false}), '');
@@ -7,6 +7,11 @@ test('get preId postfix', async t => {
 });
 
 test('no options passed', async t => {
-	await t.throwsAsync(getPreReleasePrefix(), {message: 'Expected `options` to be of type `object` but received type `undefined`'});
-	await t.throwsAsync(getPreReleasePrefix({}), {message: 'Expected object `options` to have keys `["yarn"]`'});
+	await t.throwsAsync(getPreReleasePrefix(), {
+		message:
+			'Expected `options` to be of type `object` but received type `undefined`'
+	});
+	await t.throwsAsync(getPreReleasePrefix({}), {
+		message: 'Expected object `options` to have keys `["yarn"]`'
+	});
 });

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -1,8 +1,8 @@
 import test from 'ava';
 import execaStub from 'execa_test_double';
 import mockery from 'mockery';
-import version from '../source/version';
-import {SilentRenderer} from './fixtures/listr-renderer';
+import version from '../source/version.js';
+import {SilentRenderer} from './fixtures/listr-renderer.js';
 
 let testedModule;
 
@@ -11,163 +11,303 @@ const run = async listr => {
 	await listr.run();
 };
 
-test.before(() => {
+test.before(async () => {
 	mockery.registerMock('execa', execaStub.execa);
 	mockery.enable({
 		useCleanCache: true,
 		warnOnReplace: false,
 		warnOnUnregistered: false
 	});
-	testedModule = require('../source/prerequisite-tasks');
+	testedModule = await import('../source/prerequisite-tasks.js');
 });
 
 test.beforeEach(() => {
 	execaStub.resetStub();
 });
 
-test.serial('public-package published on npm registry: should fail when npm registry not pingable', async t => {
-	execaStub.createStub([{
-		command: 'npm ping',
-		exitCode: 1,
-		exitCodeName: 'EPERM',
-		stdout: '',
-		stderr: 'failed'
-	}]);
-	await t.throwsAsync(run(testedModule('1.0.0', {name: 'test'}, {})),
-		{message: 'Connection to npm registry failed'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && task.hasFailed()));
-});
+test.serial(
+	'public-package published on npm registry: should fail when npm registry not pingable',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'npm ping',
+				exitCode: 1,
+				exitCodeName: 'EPERM',
+				stdout: '',
+				stderr: 'failed'
+			}
+		]);
+		await t.throwsAsync(run(testedModule('1.0.0', {name: 'test'}, {})), {
+			message: 'Connection to npm registry failed'
+		});
+		t.true(
+			SilentRenderer.tasks.some(
+				task => task.title === 'Ping npm registry' && task.hasFailed()
+			)
+		);
+	}
+);
 
-test.serial('private package: should disable task pinging npm registry', async t => {
-	execaStub.createStub([
-		{
-			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
-			exitCode: 0,
-			stdout: ''
-		}
-	]);
-	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && !task.isEnabled()));
-});
+test.serial(
+	'private package: should disable task pinging npm registry',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+				exitCode: 0,
+				stdout: ''
+			}
+		]);
+		await run(
+			testedModule(
+				'2.0.0',
+				{name: 'test', version: '1.0.0', private: true},
+				{yarn: false}
+			)
+		);
+		t.true(
+			SilentRenderer.tasks.some(
+				task => task.title === 'Ping npm registry' && !task.isEnabled()
+			)
+		);
+	}
+);
 
-test.serial('external registry: should disable task pinging npm registry', async t => {
-	execaStub.createStub([
-		{
-			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
-			exitCode: 0,
-			stdout: ''
-		}
-	]);
-	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', publishConfig: {registry: 'http://my.io'}},
-		{yarn: false}));
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Ping npm registry' && !task.isEnabled()));
-});
+test.serial(
+	'external registry: should disable task pinging npm registry',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+				exitCode: 0,
+				stdout: ''
+			}
+		]);
+		await run(
+			testedModule(
+				'2.0.0',
+				{
+					name: 'test',
+					version: '1.0.0',
+					publishConfig: {registry: 'http://my.io'}
+				},
+				{yarn: false}
+			)
+		);
+		t.true(
+			SilentRenderer.tasks.some(
+				task => task.title === 'Ping npm registry' && !task.isEnabled()
+			)
+		);
+	}
+);
 
-test.serial('should fail when npm version does not match range in `package.json`', async t => {
-	execaStub.createStub([
-		{
-			command: 'npm --version',
-			exitCode: 0,
-			stdout: '6.0.0'
-		},
-		{
-			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
-			exitCode: 0,
-			stdout: ''
-		}
-	]);
-	const depRange = require('../package.json').engines.npm;
-	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
-		{message: `Please upgrade to npm${depRange}`});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check npm version' && task.hasFailed()));
-});
+test.serial(
+	'should fail when npm version does not match range in `package.json`',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'npm --version',
+				exitCode: 0,
+				stdout: '6.0.0'
+			},
+			{
+				command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+				exitCode: 0,
+				stdout: ''
+			}
+		]);
+		const depRange = (await import('../package.json')).engines.npm;
+		await t.throwsAsync(
+			run(
+				testedModule(
+					'2.0.0',
+					{name: 'test', version: '1.0.0'},
+					{yarn: false}
+				)
+			),
+			{message: `Please upgrade to npm${depRange}`}
+		);
+		t.true(
+			SilentRenderer.tasks.some(
+				task => task.title === 'Check npm version' && task.hasFailed()
+			)
+		);
+	}
+);
 
-test.serial('should fail when yarn version does not match range in `package.json`', async t => {
-	execaStub.createStub([
-		{
-			command: 'yarn --version',
-			exitCode: 0,
-			stdout: '1.0.0'
-		},
-		{
-			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
-			exitCode: 0,
-			stdout: ''
-		}
-	]);
-	const depRange = require('../package.json').engines.yarn;
-	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: true})),
-		{message: `Please upgrade to yarn${depRange}`});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check yarn version' && task.hasFailed()));
-});
+test.serial(
+	'should fail when yarn version does not match range in `package.json`',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'yarn --version',
+				exitCode: 0,
+				stdout: '1.0.0'
+			},
+			{
+				command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+				exitCode: 0,
+				stdout: ''
+			}
+		]);
+		const depRange = (await import('../package.json')).engines.yarn;
+		await t.throwsAsync(
+			run(
+				testedModule(
+					'2.0.0',
+					{name: 'test', version: '1.0.0'},
+					{yarn: true}
+				)
+			),
+			{message: `Please upgrade to yarn${depRange}`}
+		);
+		t.true(
+			SilentRenderer.tasks.some(
+				task => task.title === 'Check yarn version' && task.hasFailed()
+			)
+		);
+	}
+);
 
-test.serial('should fail when user is not authenticated at npm registry', async t => {
-	execaStub.createStub([
-		{
-			command: 'npm whoami',
-			exitCode: 0,
-			stdout: 'sindresorhus'
-		},
-		{
-			command: 'npm access ls-collaborators test',
-			exitCode: 0,
-			stdout: '{"sindresorhus": "read"}'
-		}
-	]);
-	process.env.NODE_ENV = 'P';
-	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
-		{message: 'You do not have write permissions required to publish this package.'});
-	process.env.NODE_ENV = 'test';
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Verify user is authenticated' && task.hasFailed()));
-});
+test.serial(
+	'should fail when user is not authenticated at npm registry',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'npm whoami',
+				exitCode: 0,
+				stdout: 'sindresorhus'
+			},
+			{
+				command: 'npm access ls-collaborators test',
+				exitCode: 0,
+				stdout: '{"sindresorhus": "read"}'
+			}
+		]);
+		process.env.NODE_ENV = 'P';
+		await t.throwsAsync(
+			run(
+				testedModule(
+					'2.0.0',
+					{name: 'test', version: '1.0.0'},
+					{yarn: false}
+				)
+			),
+			{
+				message:
+					'You do not have write permissions required to publish this package.'
+			}
+		);
+		process.env.NODE_ENV = 'test';
+		t.true(
+			SilentRenderer.tasks.some(
+				task =>
+					task.title === 'Verify user is authenticated' && task.hasFailed()
+			)
+		);
+	}
+);
 
-test.serial('should fail when user is not authenticated at external registry', async t => {
-	execaStub.createStub([
-		{
-			command: 'npm whoami --registry http://my.io',
-			exitCode: 0,
-			stdout: 'sindresorhus'
-		},
-		{
-			command: 'npm access ls-collaborators test --registry http://my.io',
-			exitCode: 0,
-			stdout: '{"sindresorhus": "read"}'
-		}
-	]);
-	process.env.NODE_ENV = 'P';
-	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0', publishConfig: {registry: 'http://my.io'}}, {yarn: false})),
-		{message: 'You do not have write permissions required to publish this package.'});
-	process.env.NODE_ENV = 'test';
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Verify user is authenticated' && task.hasFailed()));
-});
+test.serial(
+	'should fail when user is not authenticated at external registry',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'npm whoami --registry http://my.io',
+				exitCode: 0,
+				stdout: 'sindresorhus'
+			},
+			{
+				command: 'npm access ls-collaborators test --registry http://my.io',
+				exitCode: 0,
+				stdout: '{"sindresorhus": "read"}'
+			}
+		]);
+		process.env.NODE_ENV = 'P';
+		await t.throwsAsync(
+			run(
+				testedModule(
+					'2.0.0',
+					{
+						name: 'test',
+						version: '1.0.0',
+						publishConfig: {registry: 'http://my.io'}
+					},
+					{yarn: false}
+				)
+			),
+			{
+				message:
+					'You do not have write permissions required to publish this package.'
+			}
+		);
+		process.env.NODE_ENV = 'test';
+		t.true(
+			SilentRenderer.tasks.some(
+				task =>
+					task.title === 'Verify user is authenticated' && task.hasFailed()
+			)
+		);
+	}
+);
 
-test.serial('private package: should disable task `verify user is authenticated`', async t => {
-	execaStub.createStub([
-		{
-			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
-			exitCode: 0,
-			stdout: ''
-		}
-	]);
-	process.env.NODE_ENV = 'P';
-	await run(testedModule('2.0.0', {name: 'test', version: '1.0.0', private: true}, {yarn: false}));
-	process.env.NODE_ENV = 'test';
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Verify user is authenticated' && !task.isEnabled()));
-});
+test.serial(
+	'private package: should disable task `verify user is authenticated`',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+				exitCode: 0,
+				stdout: ''
+			}
+		]);
+		process.env.NODE_ENV = 'P';
+		await run(
+			testedModule(
+				'2.0.0',
+				{name: 'test', version: '1.0.0', private: true},
+				{yarn: false}
+			)
+		);
+		process.env.NODE_ENV = 'test';
+		t.true(
+			SilentRenderer.tasks.some(
+				task =>
+					task.title === 'Verify user is authenticated' && !task.isEnabled()
+			)
+		);
+	}
+);
 
-test.serial('should fail when git version does not match range in `package.json`', async t => {
-	execaStub.createStub([
-		{
-			command: 'git version',
-			exitCode: 0,
-			stdout: 'git version 1.0.0'
-		}
-	]);
-	const depRange = require('../package.json').engines.git;
-	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
-		{message: `Please upgrade to git${depRange}`});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check git version' && task.hasFailed()));
-});
+test.serial(
+	'should fail when git version does not match range in `package.json`',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git version',
+				exitCode: 0,
+				stdout: 'git version 1.0.0'
+			}
+		]);
+		const depRange = (await import('../package.json')).engines.git;
+		await t.throwsAsync(
+			run(
+				testedModule(
+					'2.0.0',
+					{name: 'test', version: '1.0.0'},
+					{yarn: false}
+				)
+			),
+			{message: `Please upgrade to git${depRange}`}
+		);
+		t.true(
+			SilentRenderer.tasks.some(
+				task => task.title === 'Check git version' && task.hasFailed()
+			)
+		);
+	}
+);
 
 test.serial('should fail when git remote does not exists', async t => {
 	execaStub.createStub([
@@ -178,48 +318,127 @@ test.serial('should fail when git remote does not exists', async t => {
 			stderr: 'not found'
 		}
 	]);
-	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
-		{message: 'not found'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check git remote' && task.hasFailed()));
+	await t.throwsAsync(
+		run(
+			testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})
+		),
+		{message: 'not found'}
+	);
+	t.true(
+		SilentRenderer.tasks.some(
+			task => task.title === 'Check git remote' && task.hasFailed()
+		)
+	);
 });
 
 test.serial('should fail when version is invalid', async t => {
-	await t.throwsAsync(run(testedModule('DDD', {name: 'test', version: '1.0.0'}, {yarn: false})),
-		{message: `Version should be either ${version.SEMVER_INCREMENTS.join(', ')}, or a valid semver version.`});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Validate version' && task.hasFailed()));
-});
-
-test.serial('should fail when version is lower as latest version', async t => {
-	await t.throwsAsync(run(testedModule('0.1.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
-		{message: 'New version `0.1.0` should be higher than current version `1.0.0`'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Validate version' && task.hasFailed()));
-});
-
-test.serial('should fail when prerelease version of public package without dist tag given', async t => {
-	await t.throwsAsync(run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0'}, {yarn: false})),
-		{message: 'You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check for pre-release version' && task.hasFailed()));
-});
-
-test.serial('should not fail when prerelease version of public package with dist tag given', async t => {
-	execaStub.createStub([
+	await t.throwsAsync(
+		run(
+			testedModule('DDD', {name: 'test', version: '1.0.0'}, {yarn: false})
+		),
 		{
-			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
-			stdout: ''
+			message: `Version should be either ${version.SEMVER_INCREMENTS.join(
+				', '
+			)}, or a valid semver version.`
 		}
-	]);
-	await t.notThrowsAsync(run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0'}, {yarn: false, tag: 'pre'})));
+	);
+	t.true(
+		SilentRenderer.tasks.some(
+			task => task.title === 'Validate version' && task.hasFailed()
+		)
+	);
 });
 
-test.serial('should not fail when prerelease version of private package without dist tag given', async t => {
-	execaStub.createStub([
-		{
-			command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
-			stdout: ''
-		}
-	]);
-	await t.notThrowsAsync(run(testedModule('2.0.0-1', {name: 'test', version: '1.0.0', private: true}, {yarn: false})));
-});
+test.serial(
+	'should fail when version is lower as latest version',
+	async t => {
+		await t.throwsAsync(
+			run(
+				testedModule(
+					'0.1.0',
+					{name: 'test', version: '1.0.0'},
+					{yarn: false}
+				)
+			),
+			{
+				message:
+					'New version `0.1.0` should be higher than current version `1.0.0`'
+			}
+		);
+		t.true(
+			SilentRenderer.tasks.some(
+				task => task.title === 'Validate version' && task.hasFailed()
+			)
+		);
+	}
+);
+
+test.serial(
+	'should fail when prerelease version of public package without dist tag given',
+	async t => {
+		await t.throwsAsync(
+			run(
+				testedModule(
+					'2.0.0-1',
+					{name: 'test', version: '1.0.0'},
+					{yarn: false}
+				)
+			),
+			{
+				message:
+					'You must specify a dist-tag using --tag when publishing a pre-release version. This prevents accidentally tagging unstable versions as "latest". https://docs.npmjs.com/cli/dist-tag'
+			}
+		);
+		t.true(
+			SilentRenderer.tasks.some(
+				task =>
+					task.title === 'Check for pre-release version' && task.hasFailed()
+			)
+		);
+	}
+);
+
+test.serial(
+	'should not fail when prerelease version of public package with dist tag given',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+				stdout: ''
+			}
+		]);
+		await t.notThrowsAsync(
+			run(
+				testedModule(
+					'2.0.0-1',
+					{name: 'test', version: '1.0.0'},
+					{yarn: false, tag: 'pre'}
+				)
+			)
+		);
+	}
+);
+
+test.serial(
+	'should not fail when prerelease version of private package without dist tag given',
+	async t => {
+		execaStub.createStub([
+			{
+				command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+				stdout: ''
+			}
+		]);
+		await t.notThrowsAsync(
+			run(
+				testedModule(
+					'2.0.0-1',
+					{name: 'test', version: '1.0.0', private: true},
+					{yarn: false}
+				)
+			)
+		);
+	}
+);
 
 test.serial('should fail when git tag already exists', async t => {
 	execaStub.createStub([
@@ -228,9 +447,17 @@ test.serial('should fail when git tag already exists', async t => {
 			stdout: 'vvb'
 		}
 	]);
-	await t.throwsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})),
-		{message: 'Git tag `v2.0.0` already exists.'});
-	t.true(SilentRenderer.tasks.some(task => task.title === 'Check git tag existence' && task.hasFailed()));
+	await t.throwsAsync(
+		run(
+			testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})
+		),
+		{message: 'Git tag `v2.0.0` already exists.'}
+	);
+	t.true(
+		SilentRenderer.tasks.some(
+			task => task.title === 'Check git tag existence' && task.hasFailed()
+		)
+	);
 });
 
 test.serial('checks should pass', async t => {
@@ -240,5 +467,9 @@ test.serial('checks should pass', async t => {
 			stdout: ''
 		}
 	]);
-	await t.notThrowsAsync(run(testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})));
+	await t.notThrowsAsync(
+		run(
+			testedModule('2.0.0', {name: 'test', version: '1.0.0'}, {yarn: false})
+		)
+	);
 });

--- a/test/version.js
+++ b/test/version.js
@@ -1,12 +1,25 @@
 import test from 'ava';
-import version from '../source/version';
+import version from '../source/version.js';
 
 test('version.SEMVER_INCREMENTS', t => {
-	t.deepEqual(version.SEMVER_INCREMENTS, ['patch', 'minor', 'major', 'prepatch', 'preminor', 'premajor', 'prerelease']);
+	t.deepEqual(version.SEMVER_INCREMENTS, [
+		'patch',
+		'minor',
+		'major',
+		'prepatch',
+		'preminor',
+		'premajor',
+		'prerelease'
+	]);
 });
 
 test('version.PRERELEASE_VERSIONS', t => {
-	t.deepEqual(version.PRERELEASE_VERSIONS, ['prepatch', 'preminor', 'premajor', 'prerelease']);
+	t.deepEqual(version.PRERELEASE_VERSIONS, [
+		'prepatch',
+		'preminor',
+		'premajor',
+		'prerelease'
+	]);
 });
 
 test('version.isValidInput', t => {
@@ -49,7 +62,8 @@ test('version.isPrereleaseOrIncrement', t => {
 });
 
 test('version.getNewVersionFrom', t => {
-	const message = 'Version should be either patch, minor, major, prepatch, preminor, premajor, prerelease or a valid semver version.';
+	const message =
+		'Version should be either patch, minor, major, prepatch, preminor, premajor, prerelease or a valid semver version.';
 
 	t.throws(() => version('1.0.0').getNewVersionFrom('patchxxx'), message);
 	t.throws(() => version('1.0.0').getNewVersionFrom('1.0.0.0'), message);


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

Fixes: #601

This PR adds ESM migration to np.

At the moment there are a few issues that prevent it from being merged.

First: `ava` doesn't support ESM with `"type": "module"` ([source](https://github.com/avajs/ava/blob/main/docs/recipes/es-modules.md)):

> As of Node.js 12.17, ECMAScript Modules are natively supported in Node.js itself. AVA 3.3 supports ESM test files, however support is incomplete. 

Running tests results in this:

```
Uncaught exception in test/git-tasks.js


  Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /home/v1rtl/Coding/forks/np/test/fixtures/listr-renderer.js
```

Also running `xo` causes these errors and i'm unsure how to fix them in a way that it doesn't break things. For example global imports:

```js
import './cli-implementation';

/*
  source/cli-implementation.js:3:1
  ✖    3:1   Imported module should be assigned                                    import/no-unassigned-import
*/
```

