### PR TITLE
Support GPG password prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"is-interactive": "^1.0.0",
 		"is-scoped": "^2.1.0",
 		"issue-regex": "^3.1.0",
-		"listr": "^0.14.3",
+		"listr2": "^3.10.0",
 		"listr-input": "^0.2.1",
 		"log-symbols": "^4.0.0",
 		"meow": "^8.1.0",

--- a/source/git-tasks.js
+++ b/source/git-tasks.js
@@ -1,5 +1,5 @@
 'use strict';
-const Listr = require('listr');
+const {Listr} = require('listr2');
 const git = require('./git-util');
 
 module.exports = options => {

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -1,5 +1,5 @@
 'use strict';
-const Listr = require('listr');
+const {Listr} = require('listr2');
 const execa = require('execa');
 const version = require('./version');
 const git = require('./git-util');

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -1,13 +1,14 @@
 import test from 'ava';
 import execaStub from 'execa_test_double';
 import mockery from 'mockery';
+import {Listr} from 'listr2';
 import {SilentRenderer} from './fixtures/listr-renderer';
 
 let testedModule;
 
 const run = async listr => {
-	listr.setRenderer(SilentRenderer);
-	await listr.run();
+	const listrStub = new Listr(listr.task, {renderer: SilentRenderer});
+	await listrStub.run();
 };
 
 test.before(() => {

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -1,14 +1,15 @@
 import test from 'ava';
 import execaStub from 'execa_test_double';
 import mockery from 'mockery';
+const {Listr} = require('listr2');
 import version from '../source/version';
 import {SilentRenderer} from './fixtures/listr-renderer';
 
 let testedModule;
 
 const run = async listr => {
-	listr.setRenderer(SilentRenderer);
-	await listr.run();
+	const listrStub = new Listr(listr.task, {renderer: SilentRenderer});
+	await listrStub.run();
 };
 
 test.before(() => {

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import execaStub from 'execa_test_double';
 import mockery from 'mockery';
-const {Listr} = require('listr2');
+import {Listr} from 'listr2';
 import version from '../source/version';
 import {SilentRenderer} from './fixtures/listr-renderer';
 


### PR DESCRIPTION
Fixes #79. I replaced `listr` by `listr2`. With `listr2` we can support GPG password prompts out of the box without modifying `listr2`.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#79: Support GPG password prompt](https://issuehunt.io/repos/40806530/issues/79)
---
</details>
<!-- /Issuehunt content-->