### PR TITLE
Exclude node_modules and .git subpaths from minimatch input string

### DIFF
--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -154,16 +154,20 @@ function npmignoreExistsInPackageRootDir() {
 	return fs.existsSync(path.resolve(rootDir, '.npmignore'));
 }
 
+function excludeGitAndNodeModulesPaths(singlePath) {
+	return !singlePath.startsWith('.git/') && !singlePath.startsWith('node_modules/');
+}
+
 async function getFilesIgnoredByDotnpmignore(pkg, fileList) {
-	const allowList = await ignoreWalker({
+	const allowList = (await ignoreWalker({
 		path: pkgDir.sync(),
 		ignoreFiles: ['.npmignore']
-	});
+	})).filter(singlePath => excludeGitAndNodeModulesPaths(singlePath));
 	return fileList.filter(minimatch.filter(getIgnoredFilesGlob(allowList, pkg.directories), {matchBase: true, dot: true}));
 }
 
 function filterFileList(globArray, fileList) {
-	const globString = globArray.length > 1 ? `{${globArray}}` : globArray[0];
+	const globString = globArray.length > 1 ? `{${globArray.filter(singlePath => excludeGitAndNodeModulesPaths(singlePath))}}` : globArray[0];
 	return fileList.filter(minimatch.filter(globString, {matchBase: true, dot: true})); // eslint-disable-line unicorn/no-fn-reference-in-iterator
 }
 


### PR DESCRIPTION
Currently, `np` is failing to publish packages which have deep-enough `node_modules` tree.

![Screenshot 2022-02-10 at 20 06 43](https://user-images.githubusercontent.com/8344688/153489907-a347b7f5-9d84-4d68-9153-2507852ec5b5.png)

It's because `allowList` and `globString` end up with thousands of paths, which overwhelm the `minimatch` whose input string-matcher length has to be maximum `1024*64=65K` characters.  I logged `allowList` just before it caused problem and it was around 450K characters!!!

This PR excludes `node_modules` and `.git/*` from `minimatch` inputs, because npm [automatically excludes](https://docs.npmjs.com/cli/v8/commands/npm-publish) these paths.

---

Fixes #634
Closes #635