### PR TITLE
Prefilter allowList - fixes #634

### DIFF
--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -161,7 +161,7 @@ async function getFilesIgnoredByDotnpmignore(pkg, fileList) {
 	});
 	// We need to filter the allowlist because it includes too many files (including .git and node_modules)
 	// Ideally, we would filter some directories directly with `ignoreWalker`.
-	const filteredAllowList = allowList.filter(minimatch.filter(`!{${filesIgnoredByDefault.join(',')}}`, { matchBase: true, dot: true }))
+	const filteredAllowList = allowList.filter(minimatch.filter(`!{${filesIgnoredByDefault.join(',')}}`, {matchBase: true, dot: true}));
 	return fileList.filter(minimatch.filter(getIgnoredFilesGlob(filteredAllowList, pkg.directories), {matchBase: true, dot: true}));
 }
 

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -159,7 +159,10 @@ async function getFilesIgnoredByDotnpmignore(pkg, fileList) {
 		path: pkgDir.sync(),
 		ignoreFiles: ['.npmignore']
 	});
-	return fileList.filter(minimatch.filter(getIgnoredFilesGlob(allowList, pkg.directories), {matchBase: true, dot: true}));
+	// We need to filter the allowlist because it includes too many files (including .git and node_modules)
+	// Ideally, we would filter some directories directly with `ignoreWalker`.
+	const filteredAllowList = allowList.filter(minimatch.filter(`!{${filesIgnoredByDefault.join(',')}}`, { matchBase: true, dot: true }))
+	return fileList.filter(minimatch.filter(getIgnoredFilesGlob(filteredAllowList, pkg.directories), {matchBase: true, dot: true}));
 }
 
 function filterFileList(globArray, fileList) {


### PR DESCRIPTION

This PR fixes the issue described in #634.

By prefiltering the `allowList` we limit the number of files supplied as a regex to minimatch. 

`allowList` (a huge list of files including files in .git and node_modules) is converted to a regex. This causes the exception `pattern too long`. It is safe to prefilter `allowList` with the patterns described in `filesIgnoredByDefault` because they could never have been supplied to npm as a file to publish. Therefore, we don't need to compute the differences.


