### PR TITLE
🐛  Fix #600: Unexpected end of json input

### DIFF
--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -95,7 +95,18 @@ exports.prereleaseTags = async packageName => {
 		tags = Object.keys(JSON.parse(stdout))
 			.filter(tag => tag !== 'latest');
 	} catch (error) {
-		if (((JSON.parse(error.stdout) || {}).error || {}).code !== 'E404') {
+		// HACK: NPM is mixing JSON with plain text errors. Luckily, the error 
+		// always starts with 'npm ERR!' (unless you have a debugger attached)
+		// so as a solution, until npm/cli#2740 is fixed, we can remove anything
+		// starting with 'npm ERR!'
+		/** @type {string} */
+		const errorMessage = error.stderr;
+		const errorJSON = errorMessage
+							.split('\n')
+							.filter((error) => !error.startsWith('npm ERR!'))
+							.join('\n')
+
+		if (((JSON.parse(errorJSON) || {}).error || {}).code !== 'E404') {
 			throw error;
 		}
 	}


### PR DESCRIPTION
NPM is mixing json with human readable error messages (npm/cli#2740)
and refuse to fix it because they want more time to plan (npm/cli#3437).
This provides a temporary fix by simply filtering out every line that starts
with `npm ERR!` so we have a clean JSON input.

As a side effect, this will be broken when attaching a debugger to the
process, but that would have been broken without this fix.

**Note:** I have not added a test, but I can try if you find that they are necessary.

<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
