### PR TITLE
Fix npm access error(#665)

### DIFF
--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -68,7 +68,8 @@ exports.collaborators = async pkg => {
 	const packageName = pkg.name;
 	ow(packageName, ow.string);
 
-	const args = ['access', 'list', 'collaborators', '--json', packageName];
+	const npmVersion = await exports.version();
+	const args = npmVersion >= '9.0.0' ? ['access', 'list', 'collaborators', '--json', packageName] : ['access', 'ls-collaborators', '--json', packageName];
 	if (exports.isExternalRegistry(pkg)) {
 		args.push('--registry', pkg.publishConfig.registry);
 	}

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -68,7 +68,7 @@ exports.collaborators = async pkg => {
 	const packageName = pkg.name;
 	ow(packageName, ow.string);
 
-	const args = ['access', 'ls-collaborators', packageName];
+	const args = ['access', 'list', 'collaborators', packageName];
 	if (exports.isExternalRegistry(pkg)) {
 		args.push('--registry', pkg.publishConfig.registry);
 	}

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -70,7 +70,7 @@ exports.collaborators = async pkg => {
 	ow(packageName, ow.string);
 
 	const npmVersion = await exports.version();
-	const args = semver.satisfies(npmVersion, '>=9.0.0') ? ['access', 'list', 'collaborators', '--json', packageName] : ['access', 'ls-collaborators', '--json', packageName];
+	const args = semver.satisfies(npmVersion, '>=9.0.0') ? ['access', 'list', 'collaborators', '--json', packageName] : ['access', 'ls-collaborators', packageName];
 	if (exports.isExternalRegistry(pkg)) {
 		args.push('--registry', pkg.publishConfig.registry);
 	}

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -10,6 +10,7 @@ const pkgDir = require('pkg-dir');
 const ignoreWalker = require('ignore-walk');
 const minimatch = require('minimatch');
 const {verifyRequirementSatisfied} = require('../version');
+const semver = require('semver');
 
 // According to https://docs.npmjs.com/files/package.json#files
 // npm's default behavior is to ignore these files.
@@ -69,7 +70,7 @@ exports.collaborators = async pkg => {
 	ow(packageName, ow.string);
 
 	const npmVersion = await exports.version();
-	const args = npmVersion >= '9.0.0' ? ['access', 'list', 'collaborators', '--json', packageName] : ['access', 'ls-collaborators', '--json', packageName];
+	const args = semver.satisfies(npmVersion, '>=9.0.0') ? ['access', 'list', 'collaborators', '--json', packageName] : ['access', 'ls-collaborators', '--json', packageName];
 	if (exports.isExternalRegistry(pkg)) {
 		args.push('--registry', pkg.publishConfig.registry);
 	}

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -70,7 +70,7 @@ exports.collaborators = async pkg => {
 	ow(packageName, ow.string);
 
 	const npmVersion = await exports.version();
-	const args = semver.satisfies(npmVersion, '>=9.0.0') ? ['access', 'list', 'collaborators', '--json', packageName] : ['access', 'ls-collaborators', packageName];
+	const args = semver.satisfies(npmVersion, '>=9.0.0') ? ['access', 'list', 'collaborators', packageName, '--json'] : ['access', 'ls-collaborators', packageName];
 	if (exports.isExternalRegistry(pkg)) {
 		args.push('--registry', pkg.publishConfig.registry);
 	}

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -10,7 +10,7 @@ let testedModule;
 
 const testArgs = async () => {
 	const npmVersion = await versionNpm();
-	return semver.satisfies(npmVersion, '>=9.0.0') ? ['list collaborators', '--json'] : ['ls-collaborators', ''];
+	return semver.satisfies(npmVersion, '>=9.0.0') ? ['list collaborators', ' --json'] : ['ls-collaborators', ''];
 };
 
 const run = async listr => {
@@ -116,7 +116,7 @@ test.serial('should fail when user is not authenticated at npm registry', async 
 			stdout: 'sindresorhus'
 		},
 		{
-			command: `npm access ${testArgs[0]} test ${testArgs[1]}`,
+			command: `npm access ${testArgs[0]} test${testArgs[1]}`,
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}
@@ -136,7 +136,7 @@ test.serial('should fail when user is not authenticated at external registry', a
 			stdout: 'sindresorhus'
 		},
 		{
-			command: `npm access ${testArgs[0]} test --registry http://my.io ${testArgs[1]}`,
+			command: `npm access ${testArgs[0]} test${testArgs[1]} --registry http://my.io`,
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -3,15 +3,8 @@ import execaStub from 'execa_test_double';
 import mockery from 'mockery';
 import version from '../source/version';
 import {SilentRenderer} from './fixtures/listr-renderer';
-import {version as versionNpm} from '../source/npm/util';
-import semver from 'semver';
 
 let testedModule;
-
-const testArgs = async () => {
-	const npmVersion = await versionNpm();
-	return semver.satisfies(npmVersion, '>=9.0.0') ? ['list collaborators', ' --json'] : ['ls-collaborators', ''];
-};
 
 const run = async listr => {
 	listr.setRenderer(SilentRenderer);
@@ -116,7 +109,7 @@ test.serial('should fail when user is not authenticated at npm registry', async 
 			stdout: 'sindresorhus'
 		},
 		{
-			command: `npm access ${testArgs[0]} test${testArgs[1]}`,
+			command: 'npm access ls-collaborators test',
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}
@@ -136,7 +129,7 @@ test.serial('should fail when user is not authenticated at external registry', a
 			stdout: 'sindresorhus'
 		},
 		{
-			command: `npm access ${testArgs[0]} test${testArgs[1]} --registry http://my.io`,
+			command: 'npm access ls-collaborators test --registry http://my.io',
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -109,7 +109,7 @@ test.serial('should fail when user is not authenticated at npm registry', async 
 			stdout: 'sindresorhus'
 		},
 		{
-			command: 'npm access ls-collaborators test',
+			command: 'npm access list collaborators test',
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}
@@ -129,7 +129,7 @@ test.serial('should fail when user is not authenticated at external registry', a
 			stdout: 'sindresorhus'
 		},
 		{
-			command: 'npm access ls-collaborators test --registry http://my.io',
+			command: 'npm access list collaborators test --registry http://my.io',
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -3,8 +3,11 @@ import execaStub from 'execa_test_double';
 import mockery from 'mockery';
 import version from '../source/version';
 import {SilentRenderer} from './fixtures/listr-renderer';
+import {version as versionNpm} from '../source/npm/util';
 
 let testedModule;
+
+const npmVersion = versionNpm();
 
 const run = async listr => {
 	listr.setRenderer(SilentRenderer);
@@ -101,6 +104,7 @@ test.serial('should fail when yarn version does not match range in `package.json
 	t.true(SilentRenderer.tasks.some(task => task.title === 'Check yarn version' && task.hasFailed()));
 });
 
+const testArgs = npmVersion >= '9.0.0' ? 'list collaborators' : 'ls-collaborators';
 test.serial('should fail when user is not authenticated at npm registry', async t => {
 	execaStub.createStub([
 		{
@@ -109,7 +113,7 @@ test.serial('should fail when user is not authenticated at npm registry', async 
 			stdout: 'sindresorhus'
 		},
 		{
-			command: 'npm access list collaborators test --json',
+			command: `npm access ${testArgs} test --json`,
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}
@@ -129,7 +133,7 @@ test.serial('should fail when user is not authenticated at external registry', a
 			stdout: 'sindresorhus'
 		},
 		{
-			command: 'npm access list collaborators test --registry http://my.io --json',
+			command: `npm access ${testArgs} test --registry http://my.io --json`,
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -10,7 +10,7 @@ let testedModule;
 
 const testArgs = async () => {
 	const npmVersion = await versionNpm();
-	return semver.satisfies(npmVersion, '>=9.0.0') ? 'list collaborators' : 'ls-collaborators';
+	return semver.satisfies(npmVersion, '>=9.0.0') ? ['list collaborators', '--json'] : ['ls-collaborators', ''];
 };
 
 const run = async listr => {
@@ -116,7 +116,7 @@ test.serial('should fail when user is not authenticated at npm registry', async 
 			stdout: 'sindresorhus'
 		},
 		{
-			command: `npm access ${testArgs} test --json`,
+			command: `npm access ${testArgs[0]} test ${testArgs[1]}`,
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}
@@ -136,7 +136,7 @@ test.serial('should fail when user is not authenticated at external registry', a
 			stdout: 'sindresorhus'
 		},
 		{
-			command: `npm access ${testArgs} test --registry http://my.io --json`,
+			command: `npm access ${testArgs[0]} test --registry http://my.io ${testArgs[1]}`,
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -109,7 +109,7 @@ test.serial('should fail when user is not authenticated at npm registry', async 
 			stdout: 'sindresorhus'
 		},
 		{
-			command: 'npm access list collaborators test',
+			command: 'npm access list collaborators test --json',
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}
@@ -129,7 +129,7 @@ test.serial('should fail when user is not authenticated at external registry', a
 			stdout: 'sindresorhus'
 		},
 		{
-			command: 'npm access list collaborators test --registry http://my.io',
+			command: 'npm access list collaborators test --registry http://my.io --json',
 			exitCode: 0,
 			stdout: '{"sindresorhus": "read"}'
 		}

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -4,10 +4,14 @@ import mockery from 'mockery';
 import version from '../source/version';
 import {SilentRenderer} from './fixtures/listr-renderer';
 import {version as versionNpm} from '../source/npm/util';
+import semver from 'semver';
 
 let testedModule;
 
-const npmVersion = versionNpm();
+const testArgs = async () => {
+	const npmVersion = await versionNpm();
+	return semver.satisfies(npmVersion, '>=9.0.0') ? 'list collaborators' : 'ls-collaborators';
+};
 
 const run = async listr => {
 	listr.setRenderer(SilentRenderer);
@@ -104,7 +108,6 @@ test.serial('should fail when yarn version does not match range in `package.json
 	t.true(SilentRenderer.tasks.some(task => task.title === 'Check yarn version' && task.hasFailed()));
 });
 
-const testArgs = npmVersion >= '9.0.0' ? 'list collaborators' : 'ls-collaborators';
 test.serial('should fail when user is not authenticated at npm registry', async t => {
 	execaStub.createStub([
 		{


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

<details>
<summary>Thank you for considering this PR</summary>
This is my first contribution to open source, so if this PR description is a bit too much, please let me know 😃 


</details>

This PR fixes the [``npm access`` error](https://github.com/sindresorhus/np/issues/665) that occurs after updating npm to version 9.0.0.

```bash
✖ Command failed with exit code 1: npm access ls-collaborators @upleveled/eslint-config-upleveled
npm ERR! code EUSAGE
npm ERR!
npm ERR! ls-collaborators is not a valid access command
npm ERR!
npm ERR! Set access level on published packages
npm ERR!
npm ERR! Usage:
npm ERR! npm access list packages [<user>|<scope>|<scope:team> [<package>]
npm ERR! npm access list collaborators [<package> [<user>]]
npm ERR! npm access get status [<package>]
npm ERR! npm access set status=public|private [<package>]
npm ERR! npm access set mfa=none|publish|automation [<package>]
npm ERR! npm access grant <read-only|read-write> <scope:team> [<package>]
npm ERR! npm access revoke <scope:team> [<package>]
npm ERR!
npm ERR! Options:
npm ERR! [--json] [--otp <otp>] [--registry <registry>]
npm ERR!
npm ERR! Run "npm help access" for more info
```
According to the [npm documentation](https://docs.npmjs.com/cli/v9/commands/npm-access) the ``npm access`` subcommands have been changed from ``ls-collaborators`` to ``list collaborators``.

Switching
```javascript
const args = ['access', 'ls-collaborators', packageName];
```
to
```javascript
const args = ['access', 'list collaborators', packageName];
```
did not work, it keeps failing with the same errors.
Changing the execa arguments (on line 77) from ``npm`` to ``npm access list collaborators`` while stripping the ``args`` variable eliminated the error.


---

Fixes #665