### PR TITLE
Add support for pnpm (don't merge)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18
+          - 16
           - 14
           - 12
           - 10

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+	"xo.enable": true,
+	"xo.format.enable": true,
+	"editor.defaultFormatter": null,
+	"[javascript]": {
+		"editor.defaultFormatter": "samverschueren.linter-xo"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "samverschueren.linter-xo"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"escape-string-regexp": "^4.0.0",
 		"execa": "^5.0.0",
 		"github-url-from-git": "^1.5.0",
+		"has-pnpm": "^1.1.1",
 		"has-yarn": "^2.1.0",
 		"hosted-git-info": "^3.0.7",
 		"ignore-walk": "^3.0.3",

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ $ np --help
     --preview               Show tasks without actually executing them
     --tag                   Publish under a given dist-tag
     --no-yarn               Don't use Yarn
+    --no-pnpm               Don't use pnpm
     --contents              Subdirectory to publish
     --no-release-draft      Skips opening a GitHub release draft
     --release-draft-only    Only opens a GitHub release draft
@@ -95,11 +96,12 @@ Currently, these are the flags you can configure:
 - `preview` - Show tasks without actually executing them (`false` by default).
 - `tag` - Publish under a given dist-tag (`latest` by default).
 - `yarn` - Use yarn if possible (`true` by default).
+- `pnpm` - Use pnpm if possible (`true` by default).
 - `contents` - Subdirectory to publish (`.` by default).
 - `releaseDraft` - Open a GitHub release draft after releasing (`true` by default).
 - `testScript` - Name of npm run script to run tests before publishing (`test` by default).
 - `2fa` - Enable 2FA on new packages (`true` by default) (setting this to `false` is not recommended).
-- `message` - The commit message used for the version bump. Any `%s` in the string will be replaced with the new version. By default, npm uses `%s` and Yarn uses `v%s`.
+- `message` - The commit message used for the version bump. Any `%s` in the string will be replaced with the new version. By default, npm and pnpm use `%s` and Yarn uses `v%s`.
 
 For example, this configures `np` to never use Yarn and to use `dist` as the subdirectory to publish:
 
@@ -167,7 +169,7 @@ You can also add `np` to a custom script in `package.json`. This can be useful i
 
 ### User-defined tests
 
-If you want to run a user-defined test script before publishing instead of the normal `npm test` or `yarn test`, you can use `--test-script` flag or the `testScript` config. This can be useful when your normal test script is running with a `--watch` flag or in case you want to run some specific tests (maybe on the packaged files) before publishing.
+If you want to run a user-defined test script before publishing instead of the normal `npm test`, `pnpm test`, or `yarn test`, you can use `--test-script` flag or the `testScript` config. This can be useful when your normal test script is running with a `--watch` flag or in case you want to run some specific tests (maybe on the packaged files) before publishing.
 
 For example, `np --test-script=publish-test` would run the `publish-test` script instead of the default `test`.
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,8 @@
+> **Note**
+> This is a fork of [np](https://github.com/sindresorhus/np) which adds support for [pnpm](https://pnpm.io). The maintainers of np [understandably don't want to support every package manager](https://github.com/sindresorhus/np/issues/251#issuecomment-400717095), so that's why this fork exists.
+>
+> Aside from adding support for `pnpm`, this fork is equivalent to the upstream version.
+
 # np [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/xojs/xo)
 
 > A better `npm publish`
@@ -319,3 +324,4 @@ npm ERR! 403 Forbidden - GET https://registry.yarnpkg.com/-/package/my-awesome-p
 - [Sindre Sorhus](https://github.com/sindresorhus)
 - [Sam Verschueren](https://github.com/SamVerschueren)
 - [Itai Steinherz](https://github.com/itaisteinherz)
+- [Travis Fischer](https://github.com/transitive-bullshit) - added support for `pnpm`

--- a/source/index.js
+++ b/source/index.js
@@ -25,16 +25,22 @@ const npm = require('./npm/util');
 const releaseTaskHelper = require('./release-task-helper');
 const util = require('./util');
 const git = require('./git-util');
+const {of} = require('rxjs');
 
 const exec = (cmd, args) => {
 	// Use `Observable` support if merged https://github.com/sindresorhus/execa/pull/26
 	const cp = execa(cmd, args);
 
+	if (!cp.stdout?.pipe) {
+		return of({});
+	}
+
 	return merge(
 		streamToObservable(cp.stdout.pipe(split())),
 		streamToObservable(cp.stderr.pipe(split())),
 		cp
-	).pipe(filter(Boolean));
+	)
+		.pipe(filter(Boolean));
 };
 
 // eslint-disable-next-line default-param-last, complexity

--- a/source/index.js
+++ b/source/index.js
@@ -31,7 +31,7 @@ const exec = (cmd, args) => {
 	// Use `Observable` support if merged https://github.com/sindresorhus/execa/pull/26
 	const cp = execa(cmd, args);
 
-	if (!cp.stdout?.pipe) {
+	if (!cp.stdout || !cp.stdout.pipe) {
 		return of({});
 	}
 

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -29,6 +29,14 @@ module.exports = (input, pkg, options) => {
 			}
 		},
 		{
+			title: 'Check pnpm version',
+			enabled: () => options.pnpm === true,
+			task: async () => {
+				const {stdout: pnpmVersion} = await execa('pnpm', ['--version']);
+				version.verifyRequirementSatisfied('pnpm', pnpmVersion);
+			}
+		},
+		{
 			title: 'Verify user is authenticated',
 			enabled: () => process.env.NODE_ENV !== 'test' && !pkg.private,
 			task: async () => {

--- a/source/ui.js
+++ b/source/ui.js
@@ -87,11 +87,13 @@ const checkNewFiles = async pkg => {
 
 	const messages = [];
 	if (newFiles.unpublished.length > 0) {
-		messages.push(`The following new files will not be part of your published package:\n${chalk.reset(newFiles.unpublished.map(path => `- ${path}`).join('\n'))}`);
+		messages.push(`The following new files will not be part of your published package:\n${chalk.reset(newFiles.unpublished.map(path => `- ${path}`).join('\n'))}`
+		);
 	}
 
 	if (newFiles.firstTime.length > 0) {
-		messages.push(`The following new files will be published the first time:\n${chalk.reset(newFiles.firstTime.map(path => `- ${path}`).join('\n'))}`);
+		messages.push(`The following new files will be published the first time:\n${chalk.reset(newFiles.firstTime.map(path => `- ${path}`).join('\n'))}`
+		);
 	}
 
 	if (!isInteractive()) {
@@ -109,11 +111,12 @@ const checkNewFiles = async pkg => {
 	return answers.confirm;
 };
 
+// eslint-disable-next-line complexity
 module.exports = async (options, pkg) => {
 	const oldVersion = pkg.version;
 	const extraBaseUrls = ['gitlab.com'];
 	const repoUrl = pkg.repository && githubUrlFromGit(pkg.repository.url, {extraBaseUrls});
-	const pkgManager = options.yarn ? 'yarn' : 'npm';
+	const pkgManager = options.yarn === true ? 'yarn' : (options.pnpm === true ? 'pnpm' : 'npm');
 	const registryUrl = await getRegistryUrl(pkgManager, pkg);
 	const releaseBranch = options.branch;
 
@@ -211,7 +214,7 @@ module.exports = async (options, pkg) => {
 		{
 			type: 'confirm',
 			name: 'publishScoped',
-			when: isScoped(pkg.name) && options.availability.isAvailable && !options.availability.isUnknown && options.runPublish && (pkg.publishConfig && pkg.publishConfig.access !== 'restricted') && !isExternalRegistry(pkg),
+			when: isScoped(pkg.name) && options.availability.isAvailable && !options.availability.isUnknown && options.runPublish && pkg.publishConfig && pkg.publishConfig.access !== 'restricted' && !isExternalRegistry(pkg),
 			message: `This scoped repo ${chalk.bold.magenta(pkg.name)} hasn't been published. Do you want to publish it publicly?`,
 			default: false
 		}

--- a/source/util.js
+++ b/source/util.js
@@ -64,6 +64,11 @@ exports.getTagVersionPrefix = pMemoize(async options => {
 			return stdout;
 		}
 
+		if (options.pnpm) {
+			const {stdout} = await execa('pnpm', ['config', 'get', 'tag-version-prefix']);
+			return stdout;
+		}
+
 		const {stdout} = await execa('npm', ['config', 'get', 'tag-version-prefix']);
 		return stdout;
 	} catch {
@@ -82,6 +87,15 @@ exports.getPreReleasePrefix = pMemoize(async options => {
 	try {
 		if (options.yarn) {
 			const {stdout} = await execa('yarn', ['config', 'get', 'preId']);
+			if (stdout !== 'undefined') {
+				return stdout;
+			}
+
+			return '';
+		}
+
+		if (options.pnpm) {
+			const {stdout} = await execa('pnpm', ['config', 'get', 'preId']);
 			if (stdout !== 'undefined') {
 				return stdout;
 			}

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -4,6 +4,7 @@ import {getTagVersionPrefix} from '../source/util';
 
 test('get tag prefix', async t => {
 	t.is(await getTagVersionPrefix({yarn: false}), 'v');
+	t.is(await getTagVersionPrefix({yarn: false, pnpm: true}), 'v');
 	t.is(await getTagVersionPrefix({yarn: true}), 'v');
 });
 


### PR DESCRIPTION
This PR adds support for the `pnpm` package manager, which has been steadily growing in popularity.

The maintainers don't want to add support for every package manager (see https://github.com/sindresorhus/np/issues/251#issuecomment-400717095), which is totally understandable — and **therefore I don't expect this PR to be merged**.

I'm just opening the PR here for visibility and to have a chance to gather feedback.

Note that I haven't added appropriate top-level unit tests for `pnpm` yet.

cc @zkochan depending on what the `np` maintainers decide, would it possibly make sense to move this fork under the `pnpm` organization? I haven't published it to NPM yet.