### PR TITLE
Add "what np isn't" section to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,6 @@
 - Monorepos are not supported.
 - Custom registries are not supported ([but could be with your help](https://github.com/sindresorhus/np/issues/420)).
 - CI is [not an ideal environment](https://github.com/sindresorhus/np/issues/619#issuecomment-994493179) for `np`. It's meant to be used locally as an interactive tool.
-- `np` is meant to be installed globally and used by a single person, not shared as a dev dependency ([for now](https://github.com/sindresorhus/np/issues/592)).
 
 ## Prerequisite
 

--- a/readme.md
+++ b/readme.md
@@ -29,9 +29,9 @@
 ### Why not
 
 - Monorepos are not supported.
-- Custom registries are not supported ([but could be, with your help](https://github.com/sindresorhus/np/issues/420))
-- CI is [not an ideal environment](https://github.com/sindresorhus/np/issues/619#issuecomment-994493179) for np, it's meant to be used locally as an interactive tool.
-- np is meant to be installed globally and used by a single person, not shared as a dev dependency ([for now](https://github.com/sindresorhus/np/issues/592)) 
+- Custom registries are not supported ([but could be with your help](https://github.com/sindresorhus/np/issues/420)).
+- CI is [not an ideal environment](https://github.com/sindresorhus/np/issues/619#issuecomment-994493179) for `np`. It's meant to be used locally as an interactive tool.
+- `np` is meant to be installed globally and used by a single person, not shared as a dev dependency ([for now](https://github.com/sindresorhus/np/issues/592)).
 
 ## Prerequisite
 

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,13 @@
 - See exactly what will be executed with [preview mode](https://github.com/sindresorhus/np/issues/391), without pushing or publishing anything remotely
 - Supports [GitHub Packages](https://github.com/features/packages)
 
+### Why not
+
+- Monorepos are not supported.
+- Custom registries are not supported ([but could be, with your help](https://github.com/sindresorhus/np/issues/420))
+- CI is [not an ideal environment](https://github.com/sindresorhus/np/issues/619#issuecomment-994493179) for np, it's meant to be used locally as an interactive tool.
+- np is meant to be installed globally and used by a single person, not shared as a dev dependency ([for now](https://github.com/sindresorhus/np/issues/592)) 
+
 ## Prerequisite
 
 - Node.js 10 or later


### PR DESCRIPTION
After triaging every single open issue in the repo, I collected the main and recurring issues and requests that people have with np and decided it might be best to add them to the readme. np isn't for everyone and it should be clear about that. People take "a better npm publish" a little too literally.

Relevant issues:

- https://github.com/sindresorhus/np/issues/592
- #420 
- https://github.com/sindresorhus/np/issues/619#issuecomment-994493179
- https://github.com/sindresorhus/np/issues/549