### PR TITLE
Show new version in non-interactive mode

### DIFF
--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -59,15 +59,7 @@ module.exports = (input, pkg, options) => {
 		{
 			title: 'Validate version',
 			task: () => {
-				if (!version.isValidInput(input)) {
-					throw new Error(`Version should be either ${version.SEMVER_INCREMENTS.join(', ')}, or a valid semver version.`);
-				}
-
-				newVersion = version(pkg.version).getNewVersionFrom(input);
-
-				if (version(pkg.version).isLowerThanOrEqualTo(newVersion)) {
-					throw new Error(`New version \`${newVersion}\` should be higher than current version \`${pkg.version}\``);
-				}
+				newVersion = version.getAndValidateNewVersionFrom(input, pkg.version);
 			}
 		},
 		{

--- a/source/ui.js
+++ b/source/ui.js
@@ -129,10 +129,13 @@ module.exports = async (options, pkg) => {
 		}
 	}
 
+	const newVersion = options.version ? version.getAndValidateNewVersionFrom(options.version, oldVersion) : undefined;
+	const versionText = chalk.dim(`(current: ${oldVersion}${newVersion ? `, next: ${prettyVersionDiff(oldVersion, newVersion)}` : ''})`);
+
 	if (options.releaseDraftOnly) {
-		console.log(`\nCreate a release draft on GitHub for ${chalk.bold.magenta(pkg.name)} ${chalk.dim(`(current: ${oldVersion})`)}\n`);
+		console.log(`\nCreate a release draft on GitHub for ${chalk.bold.magenta(pkg.name)} ${versionText}\n`);
 	} else {
-		console.log(`\nPublish a new version of ${chalk.bold.magenta(pkg.name)} ${chalk.dim(`(current: ${oldVersion})`)}\n`);
+		console.log(`\nPublish a new version of ${chalk.bold.magenta(pkg.name)} ${versionText}\n`);
 	}
 
 	const prompts = [

--- a/source/ui.js
+++ b/source/ui.js
@@ -129,12 +129,12 @@ module.exports = async (options, pkg) => {
 		}
 	}
 
-	const newVersion = options.version ? version.getAndValidateNewVersionFrom(options.version, oldVersion) : undefined;
-	const versionText = chalk.dim(`(current: ${oldVersion}${newVersion ? `, next: ${prettyVersionDiff(oldVersion, newVersion)}` : ''})`);
-
 	if (options.releaseDraftOnly) {
 		console.log(`\nCreate a release draft on GitHub for ${chalk.bold.magenta(pkg.name)} ${versionText}\n`);
 	} else {
+		const newVersion = options.version ? version.getAndValidateNewVersionFrom(options.version, oldVersion) : undefined;
+		const versionText = chalk.dim(`(current: ${oldVersion}${newVersion ? `, next: ${prettyVersionDiff(oldVersion, newVersion)}` : ''})`);
+
 		console.log(`\nPublish a new version of ${chalk.bold.magenta(pkg.name)} ${versionText}\n`);
 	}
 

--- a/source/ui.js
+++ b/source/ui.js
@@ -133,7 +133,7 @@ module.exports = async (options, pkg) => {
 		console.log(`\nCreate a release draft on GitHub for ${chalk.bold.magenta(pkg.name)} ${chalk.dim(`(current: ${oldVersion})`)}\n`);
 	} else {
 		const newVersion = options.version ? version.getAndValidateNewVersionFrom(options.version, oldVersion) : undefined;
-		const versionText = chalk.dim(`(current: ${oldVersion}${newVersion ? `, next: ${prettyVersionDiff(oldVersion, newVersion)}` : ''})`);
+		const versionText = chalk.dim(`(current: ${oldVersion}${newVersion ? `, next: ${prettyVersionDiff(oldVersion, newVersion)}` : ''}${chalk.dim(')')}`);
 
 		console.log(`\nPublish a new version of ${chalk.bold.magenta(pkg.name)} ${versionText}\n`);
 	}

--- a/source/ui.js
+++ b/source/ui.js
@@ -130,7 +130,7 @@ module.exports = async (options, pkg) => {
 	}
 
 	if (options.releaseDraftOnly) {
-		console.log(`\nCreate a release draft on GitHub for ${chalk.bold.magenta(pkg.name)} ${versionText}\n`);
+		console.log(`\nCreate a release draft on GitHub for ${chalk.bold.magenta(pkg.name)} ${chalk.dim(`(current: ${oldVersion})`)}\n`);
 	} else {
 		const newVersion = options.version ? version.getAndValidateNewVersionFrom(options.version, oldVersion) : undefined;
 		const versionText = chalk.dim(`(current: ${oldVersion}${newVersion ? `, next: ${prettyVersionDiff(oldVersion, newVersion)}` : ''})`);

--- a/source/version.js
+++ b/source/version.js
@@ -20,7 +20,7 @@ class Version {
 	getNewVersionFrom(input) {
 		module.exports.validate(this.version);
 		if (!module.exports.isValidInput(input)) {
-			throw new Error(`Version should be either ${module.exports.SEMVER_INCREMENTS.join(', ')} or a valid semver version.`);
+			throw new Error(`Version should be either ${module.exports.SEMVER_INCREMENTS.join(', ')}, or a valid semver version.`);
 		}
 
 		return module.exports.SEMVER_INCREMENTS.includes(input) ? semver.inc(this.version, input) : input;

--- a/source/version.js
+++ b/source/version.js
@@ -64,3 +64,13 @@ module.exports.verifyRequirementSatisfied = (dependency, version) => {
 		throw new Error(`Please upgrade to ${dependency}${depRange}`);
 	}
 };
+
+module.exports.getAndValidateNewVersionFrom = (input, version) => {
+	const newVersion = module.exports(version).getNewVersionFrom(input);
+
+	if (module.exports(version).isLowerThanOrEqualTo(newVersion)) {
+		throw new Error(`New version \`${newVersion}\` should be higher than current version \`${version}\``);
+	}
+
+	return newVersion;
+};

--- a/test/version.js
+++ b/test/version.js
@@ -120,5 +120,20 @@ test('version.satisfies', t => {
 });
 
 test('version.getAndValidateNewVersionFrom', t => {
+	t.is(version.getAndValidateNewVersionFrom('patch', '1.0.0'), '1.0.1');
 
+	t.throws(
+		() => version.getAndValidateNewVersionFrom('patch', '1'),
+		'Version should be a valid semver version.'
+	);
+
+	t.throws(
+		() => version.getAndValidateNewVersionFrom('lol', '1.0.0'),
+		`Version should be either ${version.SEMVER_INCREMENTS.join(', ')}, or a valid semver version.`
+	);
+
+	t.throws(
+		() => version.getAndValidateNewVersionFrom('1.0.0', '2.0.0'),
+		'New version `1.0.0` should be higher than current version `2.0.0`'
+	);
 });

--- a/test/version.js
+++ b/test/version.js
@@ -49,7 +49,7 @@ test('version.isPrereleaseOrIncrement', t => {
 });
 
 test('version.getNewVersionFrom', t => {
-	const message = 'Version should be either patch, minor, major, prepatch, preminor, premajor, prerelease or a valid semver version.';
+	const message = 'Version should be either patch, minor, major, prepatch, preminor, premajor, prerelease, or a valid semver version.';
 
 	t.throws(() => version('1.0.0').getNewVersionFrom('patchxxx'), message);
 	t.throws(() => version('1.0.0').getNewVersionFrom('1.0.0.0'), message);

--- a/test/version.js
+++ b/test/version.js
@@ -118,3 +118,7 @@ test('version.satisfies', t => {
 	t.false(version('3.0.0').satisfies('>=2.15.8 <3.0.0 || >=3.10.1'));
 	t.false(version('3.10.0').satisfies('>=2.15.8 <3.0.0 || >=3.10.1'));
 });
+
+test('version.getAndValidateNewVersionFrom', t => {
+
+});


### PR DESCRIPTION
Closes #375.

Shows the new version in non-interactive mode (e.g. when running `np minor`) in pretty-diff form:

<p align="center"><img width="625" alt="image" src="https://user-images.githubusercontent.com/1403701/228125898-dd8049d9-3085-4378-95a7-82c1aa8ec804.png"></p>

