### PR TITLE
Fix missing word in `checkNewFiles`

### DIFF
--- a/source/ui.js
+++ b/source/ui.js
@@ -91,7 +91,7 @@ const checkNewFiles = async pkg => {
 	}
 
 	if (newFiles.firstTime.length > 0) {
-		messages.push(`The following new files will be published the first time:\n${chalk.reset(newFiles.firstTime.map(path => `- ${path}`).join('\n'))}`);
+		messages.push(`The following new files will be published for the first time:\n${chalk.reset(newFiles.firstTime.map(path => `- ${path}`).join('\n'))}`);
 	}
 
 	if (!isInteractive()) {


### PR DESCRIPTION
The following message was missing the word `for`:

https://github.com/sindresorhus/np/blob/aa23a92bcaf710068f01ed5fe50d3039b510e223/source/ui.js#L93-L95

"The following new files will be published FOR the first time"