### PR TITLE
Add check for new dependencies

### DIFF
--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -98,7 +98,7 @@ const cli = meow(`
 updateNotifier({pkg: cli.pkg}).notify();
 
 (async () => {
-	const pkg = util.readPkg();
+	const {pkg, pkgPath} = util.readPkg();
 
 	const defaultFlags = {
 		cleanup: true,
@@ -139,7 +139,7 @@ updateNotifier({pkg: cli.pkg}).notify();
 		version,
 		runPublish,
 		branch
-	}, pkg);
+	}, {pkg, pkgPath});
 
 	if (!options.confirm) {
 		process.exit(0);

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('path');
 const execa = require('execa');
 const escapeStringRegexp = require('escape-string-regexp');
 const ignoreWalker = require('ignore-walk');
@@ -7,6 +8,11 @@ const {verifyRequirementSatisfied} = require('./version');
 
 exports.latestTag = async () => {
 	const {stdout} = await execa('git', ['describe', '--abbrev=0', '--tags']);
+	return stdout;
+};
+
+exports.root = async () => {
+	const {stdout} = await execa('git', ['rev-parse', '--show-toplevel']);
 	return stdout;
 };
 
@@ -26,6 +32,12 @@ exports.newFilesSinceLastRelease = async () => {
 			ignoreFiles: ['.gitignore']
 		});
 	}
+};
+
+exports.readFileFromLastRelease = async file => {
+	const filePathFromRoot = path.relative(await exports.root(), file);
+	const {stdout: oldFile} = await execa('git', ['show', `${await this.latestTag()}:${filePathFromRoot}`]);
+	return oldFile;
 };
 
 const firstCommit = async () => {

--- a/source/index.js
+++ b/source/index.js
@@ -47,7 +47,7 @@ module.exports = async (input = 'patch', options) => {
 		options.cleanup = false;
 	}
 
-	const pkg = util.readPkg(options.contents);
+	const {pkg} = util.readPkg(options.contents);
 	const runTests = options.tests && !options.yolo;
 	const runCleanup = options.cleanup && !options.yolo;
 	const pkgManager = options.yarn === true ? 'yarn' : 'npm';
@@ -75,7 +75,7 @@ module.exports = async (input = 'patch', options) => {
 		const versionInLatestTag = latestTag.slice(tagVersionPrefix.length);
 
 		try {
-			if (versionInLatestTag === util.readPkg().version &&
+			if (versionInLatestTag === util.readPkg().pkg.version &&
 				versionInLatestTag !== pkg.version) { // Verify that the package's version has been bumped before deleting the last tag and commit.
 				await git.deleteTag(latestTag);
 				await git.removeLastCommit();


### PR DESCRIPTION
Closes #624.

Adds a confirmation step for new dependencies that have been added since the last release:

<p align="center"><img width="608" alt="image" src="https://user-images.githubusercontent.com/1403701/228758556-7eee362e-fd99-4274-8e2d-b3e491fa5a1e.png"></p>

It's part of the same check as for new files, so there's no additional prompts.