### PR TITLE
Fix remote history check - check if `git fetch` needs to be run

### DIFF
--- a/source/git-util.js
+++ b/source/git-util.js
@@ -139,8 +139,8 @@ const hasUnfetchedChangesFromRemote = async () => {
 		({stderr: possibleNewChanges} = await execa('git', ['fetch', 'origin', '--dry-run']));
 	} catch {}
 
-	// There are no unfetched changes if output is empty
-	return possibleNewChanges?.length === 0;
+	// There are no unfetched changes if output is empty.
+	return possibleNewChanges === '';
 };
 
 const isRemoteHistoryClean = async () => {
@@ -149,8 +149,8 @@ const isRemoteHistoryClean = async () => {
 		({stdout: history} = await execa('git', ['rev-list', '--count', '--left-only', '@{u}...HEAD']));
 	} catch {}
 
-	// Remote history is clean if there are 0 revisions
-	return history === '0';
+	// Remote history is clean if there are 0 revisions or if no remote set up.
+	return history === '0' || history === '';
 };
 
 export const verifyRemoteHistoryIsClean = async () => {

--- a/source/git-util.js
+++ b/source/git-util.js
@@ -144,7 +144,7 @@ const hasRemote = async () => {
 };
 
 const hasUnfetchedChangesFromRemote = async () => {
-	const {stderr: possibleNewChanges} = await execa('git', ['fetch', '--dry-run']);
+	const {stdout: possibleNewChanges} = await execa('git', ['fetch', '--dry-run']);
 
 	// There are no unfetched changes if output is empty.
 	return !possibleNewChanges || possibleNewChanges === '';

--- a/test/_utils.js
+++ b/test/_utils.js
@@ -22,7 +22,7 @@ const makeExecaStub = commands => {
 	return stub;
 };
 
-export const _stubExeca = source => async (t, commands) => {
+export const _stubExeca = source => async commands => {
 	const execaStub = makeExecaStub(commands);
 
 	return esmock(source, {}, {

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -92,7 +92,7 @@ test.serial('should fail when local working tree modified', async t => {
 	assertTaskFailed(t, 'Check local working tree');
 });
 
-test.serial('should fail when remote history differs', async t => {
+test.serial('should not fail when no remote set up', async t => {
 	const gitTasks = await stubExeca(t, [
 		{
 			command: 'git symbolic-ref --short HEAD',
@@ -101,6 +101,35 @@ test.serial('should fail when remote history differs', async t => {
 		},
 		{
 			command: 'git status --porcelain',
+			exitCode: 0,
+			stdout: '',
+		},
+		{
+			command: 'git rev-list --count --left-only @{u}...HEAD',
+			stdout: '',
+			stderr: 'fatal: no upstream configured for branch \'master\'',
+		},
+	]);
+
+	await t.notThrowsAsync(
+		run(gitTasks({branch: 'master'})),
+	);
+});
+
+test.serial('should fail when remote history differs and changes are fetched', async t => {
+	const gitTasks = await stubExeca(t, [
+		{
+			command: 'git symbolic-ref --short HEAD',
+			exitCode: 0,
+			stdout: 'master',
+		},
+		{
+			command: 'git status --porcelain',
+			exitCode: 0,
+			stdout: '',
+		},
+		{
+			command: 'git fetch origin --dry-run',
 			exitCode: 0,
 			stdout: '',
 		},

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -17,7 +17,6 @@ test.afterEach(() => {
 test.serial('should fail when release branch is not specified, current branch is not the release branch, and publishing from any branch not permitted', async t => {
 	const gitTasks = await stubExeca(t, [{
 		command: 'git symbolic-ref --short HEAD',
-		exitCode: 0,
 		stdout: 'feature',
 	}]);
 
@@ -32,7 +31,6 @@ test.serial('should fail when release branch is not specified, current branch is
 test.serial('should fail when current branch is not the specified release branch and publishing from any branch not permitted', async t => {
 	const gitTasks = await stubExeca(t, [{
 		command: 'git symbolic-ref --short HEAD',
-		exitCode: 0,
 		stdout: 'feature',
 	}]);
 
@@ -48,12 +46,10 @@ test.serial('should not fail when current branch not master and publishing from 
 	const gitTasks = await stubExeca(t, [
 		{
 			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
 			stdout: 'feature',
 		},
 		{
 			command: 'git status --porcelain',
-			exitCode: 0,
 			stdout: '',
 		},
 		{
@@ -66,7 +62,6 @@ test.serial('should not fail when current branch not master and publishing from 
 		},
 		{
 			command: 'git rev-list --count --left-only @{u}...HEAD',
-			exitCode: 0,
 			stdout: '0',
 		},
 	]);
@@ -82,12 +77,10 @@ test.serial('should fail when local working tree modified', async t => {
 	const gitTasks = await stubExeca(t, [
 		{
 			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
 			stdout: 'master',
 		},
 		{
 			command: 'git status --porcelain',
-			exitCode: 0,
 			stdout: 'M source/git-tasks.js',
 		},
 	]);
@@ -104,17 +97,14 @@ test.serial('should not fail when no remote set up', async t => {
 	const gitTasks = await stubExeca(t, [
 		{
 			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
 			stdout: 'master',
 		},
 		{
 			command: 'git status --porcelain',
-			exitCode: 0,
 			stdout: '',
 		},
 		{
 			command: 'git rev-parse @{u}',
-			stdout: '',
 			stderr: 'fatal: no upstream configured for branch \'master\'',
 		},
 	]);
@@ -128,12 +118,10 @@ test.serial('should fail when remote history differs and changes are fetched', a
 	const gitTasks = await stubExeca(t, [
 		{
 			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
 			stdout: 'master',
 		},
 		{
 			command: 'git status --porcelain',
-			exitCode: 0,
 			stdout: '',
 		},
 		{
@@ -146,7 +134,6 @@ test.serial('should fail when remote history differs and changes are fetched', a
 		},
 		{
 			command: 'git rev-list --count --left-only @{u}...HEAD',
-			exitCode: 0,
 			stdout: '1', // Has unpulled changes
 		},
 	]);
@@ -163,12 +150,10 @@ test.serial('should fail when remote has unfetched changes', async t => {
 	const gitTasks = await stubExeca(t, [
 		{
 			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
 			stdout: 'master',
 		},
 		{
 			command: 'git status --porcelain',
-			exitCode: 0,
 			stdout: '',
 		},
 		{
@@ -177,7 +162,7 @@ test.serial('should fail when remote has unfetched changes', async t => {
 		},
 		{
 			command: 'git fetch --dry-run',
-			stderr: 'From https://github.com/sindresorhus/np', // Has unfetched changes
+			stdout: 'From https://github.com/sindresorhus/np', // Has unfetched changes
 		},
 	]);
 
@@ -193,12 +178,10 @@ test.serial('checks should pass when publishing from master, working tree is cle
 	const gitTasks = await stubExeca(t, [
 		{
 			command: 'git symbolic-ref --short HEAD',
-			exitCode: 0,
 			stdout: 'master',
 		},
 		{
 			command: 'git status --porcelain',
-			exitCode: 0,
 			stdout: '',
 		},
 		{
@@ -211,7 +194,6 @@ test.serial('checks should pass when publishing from master, working tree is cle
 		},
 		{
 			command: 'git rev-list --count --left-only @{u}...HEAD',
-			exitCode: 0,
 			stdout: '0',
 		},
 	]);

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -15,7 +15,7 @@ test.afterEach(() => {
 });
 
 test.serial('should fail when release branch is not specified, current branch is not the release branch, and publishing from any branch not permitted', async t => {
-	const gitTasks = await stubExeca(t, [{
+	const gitTasks = await stubExeca([{
 		command: 'git symbolic-ref --short HEAD',
 		stdout: 'feature',
 	}]);
@@ -29,7 +29,7 @@ test.serial('should fail when release branch is not specified, current branch is
 });
 
 test.serial('should fail when current branch is not the specified release branch and publishing from any branch not permitted', async t => {
-	const gitTasks = await stubExeca(t, [{
+	const gitTasks = await stubExeca([{
 		command: 'git symbolic-ref --short HEAD',
 		stdout: 'feature',
 	}]);
@@ -43,7 +43,7 @@ test.serial('should fail when current branch is not the specified release branch
 });
 
 test.serial('should not fail when current branch not master and publishing from any branch permitted', async t => {
-	const gitTasks = await stubExeca(t, [
+	const gitTasks = await stubExeca([
 		{
 			command: 'git symbolic-ref --short HEAD',
 			stdout: 'feature',
@@ -74,7 +74,7 @@ test.serial('should not fail when current branch not master and publishing from 
 });
 
 test.serial('should fail when local working tree modified', async t => {
-	const gitTasks = await stubExeca(t, [
+	const gitTasks = await stubExeca([
 		{
 			command: 'git symbolic-ref --short HEAD',
 			stdout: 'master',
@@ -94,7 +94,7 @@ test.serial('should fail when local working tree modified', async t => {
 });
 
 test.serial('should not fail when no remote set up', async t => {
-	const gitTasks = await stubExeca(t, [
+	const gitTasks = await stubExeca([
 		{
 			command: 'git symbolic-ref --short HEAD',
 			stdout: 'master',
@@ -115,7 +115,7 @@ test.serial('should not fail when no remote set up', async t => {
 });
 
 test.serial('should fail when remote history differs and changes are fetched', async t => {
-	const gitTasks = await stubExeca(t, [
+	const gitTasks = await stubExeca([
 		{
 			command: 'git symbolic-ref --short HEAD',
 			stdout: 'master',
@@ -147,7 +147,7 @@ test.serial('should fail when remote history differs and changes are fetched', a
 });
 
 test.serial('should fail when remote has unfetched changes', async t => {
-	const gitTasks = await stubExeca(t, [
+	const gitTasks = await stubExeca([
 		{
 			command: 'git symbolic-ref --short HEAD',
 			stdout: 'master',
@@ -175,7 +175,7 @@ test.serial('should fail when remote has unfetched changes', async t => {
 });
 
 test.serial('checks should pass when publishing from master, working tree is clean and remote history not different', async t => {
-	const gitTasks = await stubExeca(t, [
+	const gitTasks = await stubExeca([
 		{
 			command: 'git symbolic-ref --short HEAD',
 			stdout: 'master',

--- a/test/git-tasks.js
+++ b/test/git-tasks.js
@@ -57,6 +57,14 @@ test.serial('should not fail when current branch not master and publishing from 
 			stdout: '',
 		},
 		{
+			command: 'git rev-parse @{u}',
+			exitCode: 0,
+		},
+		{
+			command: 'git fetch --dry-run',
+			exitCode: 0,
+		},
+		{
 			command: 'git rev-list --count --left-only @{u}...HEAD',
 			exitCode: 0,
 			stdout: '0',
@@ -105,7 +113,7 @@ test.serial('should not fail when no remote set up', async t => {
 			stdout: '',
 		},
 		{
-			command: 'git rev-list --count --left-only @{u}...HEAD',
+			command: 'git rev-parse @{u}',
 			stdout: '',
 			stderr: 'fatal: no upstream configured for branch \'master\'',
 		},
@@ -129,9 +137,12 @@ test.serial('should fail when remote history differs and changes are fetched', a
 			stdout: '',
 		},
 		{
-			command: 'git fetch origin --dry-run',
+			command: 'git rev-parse @{u}',
 			exitCode: 0,
-			stdout: '',
+		},
+		{
+			command: 'git fetch --dry-run',
+			exitCode: 0,
 		},
 		{
 			command: 'git rev-list --count --left-only @{u}...HEAD',
@@ -161,9 +172,12 @@ test.serial('should fail when remote has unfetched changes', async t => {
 			stdout: '',
 		},
 		{
-			command: 'git fetch origin --dry-run',
+			command: 'git rev-parse @{u}',
 			exitCode: 0,
-			stdout: 'From https://github.com/sindresorhus/np', // Has unfetched changes
+		},
+		{
+			command: 'git fetch --dry-run',
+			stderr: 'From https://github.com/sindresorhus/np', // Has unfetched changes
 		},
 	]);
 
@@ -186,6 +200,14 @@ test.serial('checks should pass when publishing from master, working tree is cle
 			command: 'git status --porcelain',
 			exitCode: 0,
 			stdout: '',
+		},
+		{
+			command: 'git rev-parse @{u}',
+			exitCode: 0,
+		},
+		{
+			command: 'git fetch --dry-run',
+			exitCode: 0,
 		},
 		{
 			command: 'git rev-list --count --left-only @{u}...HEAD',

--- a/test/prerequisite-tasks.js
+++ b/test/prerequisite-tasks.js
@@ -20,7 +20,7 @@ test.afterEach(() => {
 });
 
 test.serial('public-package published on npm registry: should fail when npm registry not pingable', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'npm ping',
 		exitCode: 1,
 		exitCodeName: 'EPERM',
@@ -37,7 +37,7 @@ test.serial('public-package published on npm registry: should fail when npm regi
 });
 
 test.serial('private package: should disable task pinging npm registry', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
 		exitCode: 0,
 		stdout: '',
@@ -51,7 +51,7 @@ test.serial('private package: should disable task pinging npm registry', async t
 });
 
 test.serial('external registry: should disable task pinging npm registry', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
 		exitCode: 0,
 		stdout: '',
@@ -65,7 +65,7 @@ test.serial('external registry: should disable task pinging npm registry', async
 });
 
 test.serial('should fail when npm version does not match range in `package.json`', async t => {
-	const prerequisiteTasks = await stubExeca(t, [
+	const prerequisiteTasks = await stubExeca([
 		{
 			command: 'npm --version',
 			exitCode: 0,
@@ -89,7 +89,7 @@ test.serial('should fail when npm version does not match range in `package.json`
 });
 
 test.serial('should fail when yarn version does not match range in `package.json`', async t => {
-	const prerequisiteTasks = await stubExeca(t, [
+	const prerequisiteTasks = await stubExeca([
 		{
 			command: 'yarn --version',
 			exitCode: 0,
@@ -113,7 +113,7 @@ test.serial('should fail when yarn version does not match range in `package.json
 });
 
 test.serial('should fail when user is not authenticated at npm registry', async t => {
-	const prerequisiteTasks = await stubExeca(t, [
+	const prerequisiteTasks = await stubExeca([
 		{
 			command: 'npm whoami',
 			exitCode: 0,
@@ -139,7 +139,7 @@ test.serial('should fail when user is not authenticated at npm registry', async 
 });
 
 test.serial('should fail when user is not authenticated at external registry', async t => {
-	const prerequisiteTasks = await stubExeca(t, [
+	const prerequisiteTasks = await stubExeca([
 		{
 			command: 'npm whoami --registry http://my.io',
 			exitCode: 0,
@@ -170,7 +170,7 @@ test.serial('should fail when user is not authenticated at external registry', a
 });
 
 test.serial('private package: should disable task `verify user is authenticated`', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
 		exitCode: 0,
 		stdout: '',
@@ -188,7 +188,7 @@ test.serial('private package: should disable task `verify user is authenticated`
 });
 
 test.serial('should fail when git version does not match range in `package.json`', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'git version',
 		exitCode: 0,
 		stdout: 'git version 1.0.0',
@@ -205,7 +205,7 @@ test.serial('should fail when git version does not match range in `package.json`
 });
 
 test.serial('should fail when git remote does not exist', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'git ls-remote origin HEAD',
 		exitCode: 1,
 		exitCodeName: 'EPERM',
@@ -248,7 +248,7 @@ test.serial('should fail when prerelease version of public package without dist 
 });
 
 test.serial('should not fail when prerelease version of public package with dist tag given', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
 		stdout: '',
 	}]);
@@ -259,7 +259,7 @@ test.serial('should not fail when prerelease version of public package with dist
 });
 
 test.serial('should not fail when prerelease version of private package without dist tag given', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
 		stdout: '',
 	}]);
@@ -270,7 +270,7 @@ test.serial('should not fail when prerelease version of private package without 
 });
 
 test.serial('should fail when git tag already exists', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
 		stdout: 'vvb',
 	}]);
@@ -284,7 +284,7 @@ test.serial('should fail when git tag already exists', async t => {
 });
 
 test.serial('checks should pass', async t => {
-	const prerequisiteTasks = await stubExeca(t, [{
+	const prerequisiteTasks = await stubExeca([{
 		command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
 		stdout: '',
 	}]);


### PR DESCRIPTION
Fixes #421.
Fixes #414.

If `np` detects that there are unfetched upstream changes (via `git fetch --dry-run`), errors with

```
Remote history differs. Please run `git fetch` and pull changes.
```

~I'm not sure if it matters that it only checks origin. I guess if the remote name differs? Should the check be `git fetch @{u} --dry-run`?~

According to the [man page](https://git-scm.com/docs/git-fetch#_description), `origin` can be omitted:

> When no remote is specified, by default the origin remote will be used, unless there’s an upstream branch configured for the current branch.