### PR TITLE
Ensure that Node version bumps are done in major releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"p-timeout": "^6.1.1",
 		"path-exists": "^5.0.0",
 		"pkg-dir": "^7.0.0",
+		"read-pkg": "^7.1.0",
 		"read-pkg-up": "^9.1.0",
 		"rxjs": "^7.8.0",
 		"semver": "^7.3.8",

--- a/source/version.js
+++ b/source/version.js
@@ -12,6 +12,12 @@ export default class Version {
 		return Boolean(semver.prerelease(this.version));
 	}
 
+	// TODO: should this be validated? it's after `getNewVersionFrom` in tasks
+	// add test in test/version.js
+	isMajor(input) {
+		return semver.diff(this.version, input) === 'major';
+	}
+
 	satisfies(range) {
 		Version.validate(this.version);
 		return semver.satisfies(this.version, range, {


### PR DESCRIPTION
Closes #88. Currently just a scaffold for a new prerequisite task.

Some questions:

- What happens if the old version defined a Node version, but the new one doesn't?
- The error message is currently `The Node version has increased, but this release is not a major version.`, but that's not the best. Any ideas for improvements?

---

Related to the first question, it just struck me - what happens with #681 on the first release? I don't think I took that case into account.