### PR TITLE
Use `renameFile` from `move-file` for `new-files` fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"common-tags": "^1.8.2",
 		"esmock": "^2.2.1",
 		"fs-extra": "^11.1.1",
+		"move-file": "^3.1.0",
 		"sinon": "^15.0.3",
 		"tempy": "^3.0.0",
 		"write-pkg": "^5.1.0",

--- a/test/new-files.js
+++ b/test/new-files.js
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import fs from 'node:fs/promises';
 import test from 'ava';
 import esmock from 'esmock';
+import {renameFile} from 'move-file';
 import {runIfExists} from './_utils.js';
 
 const getFixture = name => path.resolve('test', 'fixtures', 'files', name);
@@ -59,10 +59,10 @@ test('package.json files field and npmignore', mockPkgDir, 'files-and-npmignore'
 
 const renameDotGitignore = {
 	async before(fixtureDir) {
-		await fs.rename(`${fixtureDir}/gitignore`, `${fixtureDir}/.gitignore`);
+		await renameFile('gitignore', '.gitignore', {cwd: fixtureDir});
 	},
 	async after(fixtureDir) {
-		await fs.rename(`${fixtureDir}/.gitignore`, `${fixtureDir}/gitignore`);
+		await renameFile('.gitignore', 'gitignore', {cwd: fixtureDir});
 	},
 };
 


### PR DESCRIPTION
Uses the method we added in https://github.com/sindresorhus/move-file/pull/23#event-8934219551 for a couple of fixtures from #682.