### PR TITLE
Add 2fa support for npm version 9+

### DIFF
--- a/source/npm/enable-2fa.js
+++ b/source/npm/enable-2fa.js
@@ -2,10 +2,10 @@ import {execa} from 'execa';
 import {from, catchError} from 'rxjs';
 import semver from 'semver';
 import handleNpmError from './handle-npm-error.js';
-import {version} from './util.js';
+import {version as npmVersionCheck} from './util.js';
 
 export const getEnable2faArgs = async (packageName, options) => {
-	const npmVersion = await version();
+	const npmVersion = await npmVersionCheck();
 	const args = semver.satisfies(npmVersion, '>=9.0.0') ? ['access', 'set', 'mfa=publish', packageName] : ['access', '2fa-required', packageName];
 
 	if (options && options.otp) {

--- a/source/npm/enable-2fa.js
+++ b/source/npm/enable-2fa.js
@@ -6,7 +6,7 @@ import {version} from './util.js';
 
 export const getEnable2faArgs = async (packageName, options) => {
 	const npmVersion = await version();
-	const args = semver.satisfies(npmVersion, '>=9.0.0') ? ['access', 'set', 'mfa', 'publish', packageName] : ['access', '2fa-required', packageName];
+	const args = semver.satisfies(npmVersion, '>=9.0.0') ? ['access', 'set', 'mfa=publish', packageName] : ['access', '2fa-required', packageName];
 
 	if (options && options.otp) {
 		args.push('--otp', options.otp);

--- a/source/npm/enable-2fa.js
+++ b/source/npm/enable-2fa.js
@@ -1,9 +1,12 @@
 import {execa} from 'execa';
 import {from, catchError} from 'rxjs';
+import semver from 'semver';
 import handleNpmError from './handle-npm-error.js';
+import {version} from './util.js';
 
-export const getEnable2faArgs = (packageName, options) => {
-	const args = ['access', '2fa-required', packageName];
+export const getEnable2faArgs = async (packageName, options) => {
+	const npmVersion = await version();
+	const args = semver.satisfies(npmVersion, '>=9.0.0') ? ['access', 'set', 'mfa', 'publish', packageName] : ['access', '2fa-required', packageName];
 
 	if (options && options.otp) {
 		args.push('--otp', options.otp);


### PR DESCRIPTION
This PR will add the support of 2fa with the npm version 9 and up.
I used the existing version check to determine which arguments should be used:
- `npm access set mfa publish <package>` for new versions
- `npm access 2fa-required <package>` for npm versions lower than 8

Fixes #692 
