### PR TITLE
improve messages related to new files/dependencies

### DIFF
--- a/source/ui.js
+++ b/source/ui.js
@@ -94,15 +94,15 @@ const checkNewFilesAndDependencies = async (pkg, rootDir) => {
 
 	const messages = [];
 	if (newFiles.unpublished.length > 0) {
-		messages.push(`The following new files will not be part of your published package:\n${util.joinList(newFiles.unpublished)}`);
+		messages.push(`The following new files will not be part of your published package:\n${util.joinList(newFiles.unpublished)}\n\nIf you intended to publish them, add them to 'files' in your package.json.`);
 	}
 
 	if (newFiles.firstTime.length > 0) {
-		messages.push(`The following new files will be published for the first time:\n${util.joinList(newFiles.firstTime)}`);
+		messages.push(`The following new files will be published for the first time:\n${util.joinList(newFiles.firstTime)}\n\nPlease make sure you intended to do that.`);
 	}
 
 	if (newDependencies.length > 0) {
-		messages.push(`The following new dependencies will be part of your published package:\n${util.joinList(newDependencies)}`);
+		messages.push(`The following new dependencies will be part of your published package:\n${util.joinList(newDependencies)}\n\nPlease make sure you intended to do that.`);
 	}
 
 	if (!isInteractive()) {

--- a/source/ui.js
+++ b/source/ui.js
@@ -98,7 +98,7 @@ const checkNewFilesAndDependencies = async (pkg, rootDir) => {
 	}
 
 	if (newFiles.firstTime.length > 0) {
-		messages.push(`The following new files will be published for the first time:\n${util.joinList(newFiles.firstTime)}\n\nPlease make sure only the intended files are published.`);
+		messages.push(`The following new files will be published for the first time:\n${util.joinList(newFiles.firstTime)}\n\nPlease make sure only the intended files are listed.`);
 	}
 
 	if (newDependencies.length > 0) {

--- a/source/ui.js
+++ b/source/ui.js
@@ -94,15 +94,15 @@ const checkNewFilesAndDependencies = async (pkg, rootDir) => {
 
 	const messages = [];
 	if (newFiles.unpublished.length > 0) {
-		messages.push(`The following new files will not be part of your published package:\n${util.joinList(newFiles.unpublished)}\n\nIf you intended to publish them, add them to 'files' in your package.json.`);
+		messages.push(`The following new files will not be part of your published package:\n${util.joinList(newFiles.unpublished)}\n\nIf you intended to publish them, add them to the \`files\` field in package.json.`);
 	}
 
 	if (newFiles.firstTime.length > 0) {
-		messages.push(`The following new files will be published for the first time:\n${util.joinList(newFiles.firstTime)}\n\nPlease make sure you intended to do that.`);
+		messages.push(`The following new files will be published for the first time:\n${util.joinList(newFiles.firstTime)}\n\nPlease make sure only the intended files are published.`);
 	}
 
 	if (newDependencies.length > 0) {
-		messages.push(`The following new dependencies will be part of your published package:\n${util.joinList(newDependencies)}\n\nPlease make sure you intended to do that.`);
+		messages.push(`The following new dependencies will be part of your published package:\n${util.joinList(newDependencies)}\n\nPlease make sure these new dependencies are intentional.`);
 	}
 
 	if (!isInteractive()) {


### PR DESCRIPTION
Whenever I come across one of these messages, I am unsure what this means for me.

This PR adds explanations on possible actions for the end user.