### PR TITLE
Handle first time display of dependencies

### DIFF
--- a/source/util.js
+++ b/source/util.js
@@ -89,6 +89,7 @@ export const getNewDependencies = async (newPkg, rootDir) => {
 	try {
 		oldPkg = await git.readFileFromLastRelease(path.resolve(rootDir, 'package.json'));
 	} catch {
+		// Handle first time publish
 		return Object.keys(newPkg.dependencies ?? {});
 	}
 

--- a/source/util.js
+++ b/source/util.js
@@ -84,7 +84,14 @@ export const getNewFiles = async rootDir => {
 };
 
 export const getNewDependencies = async (newPkg, rootDir) => {
-	let oldPkg = await git.readFileFromLastRelease(path.resolve(rootDir, 'package.json'));
+	let oldPkg;
+
+	try {
+		oldPkg = await git.readFileFromLastRelease(path.resolve(rootDir, 'package.json'));
+	} catch {
+		return Object.keys(newPkg.dependencies ?? {});
+	}
+
 	oldPkg = JSON.parse(oldPkg);
 
 	const newDependencies = [];


### PR DESCRIPTION
Fixes #699. `util.getNewDependencies` currently fails on first publish, as there's no previous release to read a `package.json` from:

https://github.com/sindresorhus/np/blob/065193375f17f40f412e0e5cedda098396c8391d/source/util.js#L86-L90

#689 should add a test case for this.