### PR TITLE
Add --no-release-notes option to disable auto-generated release notes in GitHub draft

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ Currently, these are the flags you can configure:
 - `yarn` - Use yarn if possible (`true` by default).
 - `contents` - Subdirectory to publish (`.` by default).
 - `releaseDraft` - Open a GitHub release draft after releasing (`true` by default).
+- `releaseNotes` - Auto-generate release notes when opening a GitHub release draft (`true` by default).
 - `testScript` - Name of npm run script to run tests before publishing (`test` by default).
 - `2fa` - Enable 2FA on new packages (`true` by default) (setting this to `false` is not recommended).
 - `message` - The commit message used for the version bump. Any `%s` in the string will be replaced with the new version. By default, npm uses `%s` and Yarn uses `v%s`.

--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -34,6 +34,7 @@ const cli = meow(`
 	  --contents             Subdirectory to publish
 	  --no-release-draft     Skips opening a GitHub release draft
 	  --release-draft-only   Only opens a GitHub release draft for the latest published version
+	  --no-release-notes     Skips generating release notes when opening a GitHub release
 	  --test-script          Name of npm run script to run tests before publishing (default: test)
 	  --no-2fa               Don't enable 2FA on new packages (not recommended)
 	  --message              Version bump commit message, '%s' will be replaced with version (default: '%s' with npm and 'v%s' with yarn)
@@ -72,6 +73,9 @@ const cli = meow(`
 		releaseDraftOnly: {
 			type: 'boolean',
 		},
+		releaseNotes: {
+			type: 'boolean',
+		},
 		tag: {
 			type: 'string',
 		},
@@ -106,6 +110,7 @@ try {
 		tests: true,
 		publish: true,
 		releaseDraft: true,
+		releaseNotes: true,
 		yarn: hasYarn(),
 		'2fa': true,
 	};

--- a/source/release-task-helper.js
+++ b/source/release-task-helper.js
@@ -14,7 +14,7 @@ const releaseTaskHelper = async (options, pkg) => {
 	const url = newGithubReleaseUrl({
 		repoUrl: options.repoUrl,
 		tag,
-		body: options.releaseNotes(tag),
+		body: options.generateReleaseNotes(tag),
 		isPrerelease: isPreRelease,
 	});
 

--- a/source/release-task-helper.js
+++ b/source/release-task-helper.js
@@ -14,7 +14,7 @@ const releaseTaskHelper = async (options, pkg) => {
 	const url = newGithubReleaseUrl({
 		repoUrl: options.repoUrl,
 		tag,
-		body: options.generateReleaseNotes(tag),
+		body: options.releaseNotes ? options.generateReleaseNotes(tag) : '',
 		isPrerelease: isPreRelease,
 	});
 

--- a/source/ui.js
+++ b/source/ui.js
@@ -22,7 +22,7 @@ const printCommitLog = async (repoUrl, registryUrl, fromLatestTag, releaseBranch
 		return {
 			hasCommits: false,
 			hasUnreleasedCommits: false,
-			releaseNotes() {},
+			generateReleaseNotes() {},
 		};
 	}
 
@@ -64,7 +64,7 @@ const printCommitLog = async (repoUrl, registryUrl, fromLatestTag, releaseBranch
 		return `- ${commitMessage}  ${commitId}`;
 	}).join('\n');
 
-	const releaseNotes = nextTag => commits.map(commit =>
+	const generateReleaseNotes = nextTag => commits.map(commit =>
 		`- ${htmlEscape(commit.message)}  ${commit.id}`,
 	).join('\n') + `\n\n${repoUrl}/compare/${revision}...${nextTag}`;
 
@@ -74,7 +74,7 @@ const printCommitLog = async (repoUrl, registryUrl, fromLatestTag, releaseBranch
 	return {
 		hasCommits: true,
 		hasUnreleasedCommits,
-		releaseNotes,
+		generateReleaseNotes,
 	};
 };
 
@@ -151,7 +151,7 @@ const ui = async (options, {pkg, rootDir}) => {
 	}
 
 	const useLatestTag = !options.releaseDraftOnly;
-	const {hasCommits, hasUnreleasedCommits, releaseNotes} = await printCommitLog(repoUrl, registryUrl, useLatestTag, releaseBranch);
+	const {hasCommits, hasUnreleasedCommits, generateReleaseNotes} = await printCommitLog(repoUrl, registryUrl, useLatestTag, releaseBranch);
 
 	if (hasUnreleasedCommits && options.releaseDraftOnly) {
 		const answers = await inquirer.prompt({
@@ -175,7 +175,7 @@ const ui = async (options, {pkg, rootDir}) => {
 			...options,
 			confirm: true,
 			repoUrl,
-			releaseNotes,
+			generateReleaseNotes,
 		};
 	}
 
@@ -296,7 +296,7 @@ const ui = async (options, {pkg, rootDir}) => {
 		publishScoped: answers.publishScoped,
 		confirm: true,
 		repoUrl,
-		releaseNotes,
+		generateReleaseNotes,
 	};
 };
 


### PR DESCRIPTION
Fixes #708