### PR TITLE
Add Node.js 20 to CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 19
+          - 20
           - 18
           - 16
     steps:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"yarn": ">=1.7.0"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && node script/test-ava.js"
 	},
 	"files": [
 		"source"

--- a/script/test-ava.js
+++ b/script/test-ava.js
@@ -1,3 +1,5 @@
+// TODO: remove when avajs/ava#3213 lands
+
 import process from 'node:process';
 import semver from 'semver';
 import {$} from 'execa';

--- a/script/test-ava.js
+++ b/script/test-ava.js
@@ -1,0 +1,11 @@
+import process from 'node:process';
+import semver from 'semver';
+import {$} from 'execa';
+
+const $$ = $({stdio: 'inherit'});
+
+if (semver.major(process.version) === 20) {
+	process.env.NODE_OPTIONS = '--loader=esmock --no-warnings=ExperimentalWarning';
+}
+
+await $$`ava`;


### PR DESCRIPTION
Until https://github.com/avajs/ava/discussions/3213#discussioncomment-6587118 lands, testing on Node.js 20 with a custom loader requires a workaround for `AVA`. I felt that adding a test script was easier than using something like `cross-env` in a `package.json` script.

Should we target Node.js 18 in this PR too?