### PR TITLE
fix: Tests timing out locally due to GPG

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
 		],
 		"environmentVariables": {
 			"FORCE_HYPERLINK": "1",
-			"HOME": "/tmp"
+			"HOME": "/tmp",
+			"GIT_AUTHOR_NAME": "test",
+			"GIT_AUTHOR_EMAIL": "test@example.com"
 		},
 		"nodeArguments": [
 			"--loader=esmock",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
 			"!test/_helpers"
 		],
 		"environmentVariables": {
-			"FORCE_HYPERLINK": "1"
+			"FORCE_HYPERLINK": "1",
+			"HOME": "/tmp"
 		},
 		"nodeArguments": [
 			"--loader=esmock",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,9 @@
 			"FORCE_HYPERLINK": "1",
 			"HOME": "/tmp",
 			"GIT_AUTHOR_NAME": "test",
-			"GIT_AUTHOR_EMAIL": "test@example.com"
+			"GIT_COMMITTER_NAME": "test",
+			"GIT_AUTHOR_EMAIL": "test@example.com",
+			"GIT_COMMITTER_EMAIL": "test@example.com"
 		},
 		"nodeArguments": [
 			"--loader=esmock",


### PR DESCRIPTION
I see that the test suite finishes in about a minute on the CI. When I run the test suite locally, it takes almost 2 minutes and then it just fails with a lot of tests timed out. The test output formatting is messed up too.

I've done some digging and I found out it's caused by GPG signing (specifically `[tag] gpgSign = true` option). Basically the test suite runs a lot of `git` commands, which in turn read from my `~/.gitconfig` file which has personal git configurations including GPG signing enabled. I'm thinking that unit tests should not be affected by the user's git config, so we should disable this.

Seems like there [isn't any option](https://stackoverflow.com/questions/23400449/how-to-make-git-temporarily-ignore-gitconfig) for git to disable reading of `~/.gitconfig`, however setting `HOME=/tmp` works, and all the tests succeed without any timeout on my computer.

note that I also tried `HOME=`, but that caused npm to create a `~` directory inside the project root as well as inside all `test/fixtures/files/*` dirs, and it wrote a lot of stuff inside them, which in turn caused `packed-files.js` tests to fail.

Full failed test output:

```bash
np mifi$ time yarn test
yarn run v1.22.19
warning np@8.0.4: The engine "git" appears to be invalid.
$ xo && ava

  source/index.js:34:2
  ⚠   34:2   Unexpected todo comment: TODO: Remove sometime far in the future.  no-warning-comments
  ⚠  266:4   Unexpected todo comment: TODO: parse version outside of index.     no-warning-comments

  source/cli-implementation.js:123:2
  ⚠  123:2   Unexpected todo comment: TODO: does this need to run if....        no-warning-comments

  source/ui.js:231:40
  ⚠  231:40  Unexpected todo comment: TODO: prerelease prefix here too.         no-warning-comments

  test/release-task-helper.js:24:1
  ⚠   24:1   Unexpected todo comment: TODO: test `body`.                        no-warning-comments

  test/git-util/previous-tag-or-first-commit.js:45:1
  ⚠   45:1   test.todo() should not be used.                                    ava/no-todo-test

  test/tasks/prerequisite-tasks.js:137:1
  ⚠  137:1   test.todo() should not be used.                                    ava/no-todo-test

  7 warnings

  ✔ version › new Version - valid
  ✔ version › new Version - invalid
  ✔ version › new Version - valid w/ valid increment
  ✔ version › new Version - invalid w/ valid increment
  ✔ version › new Version - valid w/ invalid increment
  ✔ version › new Version - invalid w/ invalid increment
  ✔ version › setFrom - valid input as version
  ✔ version › setFrom - invalid input as version
  ✔ version › setFrom - valid input is not higher than version
  ✔ version › format
  ✔ version › format - set diff
  ✔ version › format - major
  ✔ version › format - minor
  ✔ version › format - patch
  ✔ version › format - premajor
  ✔ version › format - preminor
  ✔ version › format - prepatch
  ✔ version › format - prerelease
  ✔ version › format - prerelease as prepatch
  ✔ version › format - prerelease with multiple numbers
  ✔ version › format - prerelease with text
  ✔ version › format - prerelease diffs
  ✔ version › format - custom colors
  ✔ version › format - previousVersion as SemVer instance
  ✔ version › format - invalid previousVersion
  ✔ version › satisfies
  ✔ version › isPrerelease
  ✔ version › optionally set prereleasePrefix
  ✔ git-util › check-if-file-git-ignored › returns false for non-ignored files
  ✔ git-util › check-if-file-git-ignored › returns true for ignored files
  ✔ git-util › check-if-file-git-ignored › errors if path is outside of repo
  ✔ config › returns config from home directory when global binary is used and .np-config-json exists in home directory (923ms)
  ✔ config › returns config from package directory when local binary is used and `.np-config.json` exists in package directory (912ms)
  ✔ config › returns config from home directory when global binary is used and `.np-config.js` as CJS exists in home directory (936ms)
  ✔ release-task-helper › main (879ms)
  ✔ [expected fail] config › returns config from home directory when global binary is used and `.np-config.js` as ESM exists in home directory
  ✔ config › returns config from package directory when local binary is used and `.np-config.js` as CJS exists in package directory (968ms)
  ✔ config › returns config from home directory when global binary is used and `.np-config.cjs` exists in home directory (1s)
  ✔ release-task-helper › handles increment as new version (931ms)
  ✔ config › returns config from package directory when local binary is used and `.np-config.cjs` exists in package directory (1s)
  ✔ release-task-helper › uses resolved prefix (962ms)
  ✔ release-task-helper › prerelease (967ms)
  ✔ config › returns config from package directory when local binary is used and `package.json` exists in package directory (1s)
  ✔ config › returns config from package directory when local binary is used and `.np-config.js` as ESM exists in package directory (1s)
  ✔ config › returns config from home directory when global binary is used and `.np-config.mjs` exists in home directory (1s)
  ✔ config › returns config from package directory when local binary is used and `.np-config.mjs` exists in package directory (1s)
  ✔ index › skip enabling 2FA if the package exists (1.3s)
  ✔ index › skip enabling 2FA if the `2fa` option is false (1.3s)
  ✔ git-util › get-current-branch › returns current branch (3.2s)
  ✔ cli › flags: --version (4.4s)
  ✔ git-util › has-upstream › no upstream (3.3s)
  ✔ cli › flags: --help (4.8s)
                                ✔ git-util › is-head-detached › not detached (4.9s)
                                                                                     ✔ git-util › is-head-detached › detached (4.9s)
                                                                                                                                      - [todo] git-util › previous-tag-or-first-commit › test fallback case
                            ✔ git-util › delete-tag › throws if tag not found (6s)
                                                                                    ✔ git-util › default-branch › main (7.6s)
                                                                                                                               ✔ git-util › default-branch › master (7.6s)
                                                                                                                                                                            ✔ git-util › default-branch › gh-pages (7.5s)
                                          ✔ git-util › default-branch › fails (7.5s)
                                                                                      ✔ git-util › push-graceful › succeeds (1.1s)
                                                                                                                                    ✔ git-util › push-graceful › fails w/ remote on GitHub and bad branch permission (1.1s)
                                            ✔ git-util › push-graceful › throws (1.1s)
                                                                                        ✔ git-util › new-files-since-last-release › uses ignoreWalker (3.4s)
                                                                                                                                                              ✔ git-util › latag-or-first-commit › no tags (fallback) (3.5s)
                                             ✔ index › version is pre-release (8s)
                                                                                    ✔ index › version is invalid (8s)
                                                                                                                       ✔ index › errors on too low version (8.3s)
                                                                                                                                                                 SYNCHRONOUS TERMINATION NOTICE: When explicitly exiting the process via process.exit or via a parent process, asynchronous tasks in your exitHooks will not run. Either remove these tasks, use gracefulExit() instead of process.exit(), or ensure your parent process sends a SIGINT to the process running this code.
                                                                                                                         ✔ git-util › previous-tag-or-first-commit › no tags (3.4s)
    ✔ git-util › remove-last-commit › removes latest commit (784ms)
                                                                     ✔ git-util › read-file-from-last-release › no previous release (1.7s)
                                                                                                                                            ✔ git-util › root › returns np root dir
    ✔ git-util › root › returns root dir of temp dir (416ms)
                                                              ✔ git-util › verify-current-branch-is-release-branch › on release branch (706ms)
                                                                                                                                                ✔ git-util › verify-current-branch-is-release-branch › not on release branch (715ms)
                                                     ✔ git-util › verify-recent-git-version › not satisfied (172ms)
                                                                                                                     ✔ git-util › verify-recent-git-version › satisfied (178ms)
                                                                                                                                                                                 ✔ git-util › verify-remote-history-is-clean › unfetched changes (248ms)
                                                                         ✔ git-util › verify-remote-history-is-clean › unclean remote history (253ms)
                                                                                                                                                       ✔ git-util › verify-remote-history-is-clean › clean fetched remote history (260ms)
                                                          ✔ git-util › verify-remote-history-is-clean › no remote (512ms)
                                                                                                                           ✔ git-util › verify-remote-is-valid › has remote (139ms)
    ✔ git-util › verify-remote-is-valid › no remote (472ms)
                                                             ✔ git-util › verify-tag-does-not-exist-on-remote › does not exist (172ms)
                                                                                                                                        ✔ git-util › verify-tag-does-not-exist-on-remote › exists (179ms)
                          ✔ git-util › verify-working-tree-is-clean › not clean (710ms)
                                                                                         ✔ git-util › verify-working-tree-is-clean › clean (784ms)
                                                                                                                                                    ✔ npm › enable-2fa › npm v8.0.0 - no options (700ms)
                         ✔ npm › enable-2fa › npm v8.0.0 - options, no otp (704ms)
                                                                                    ✔ npm › enable-2fa › npm v8.0.0 - options, with otp (710ms)
                                                                                                                                                 ✔ npm › enable-2fa › npm v9.0.0 - options, no otp (714ms)
                           ✔ npm › enable-2fa › npm v9.0.0 - no options (719ms)
                                                                                 ✔ npm › enable-2fa › npm v9.0.0 - options, with otp (724ms)
                                                                                                                                              ✔ npm › handle-npm-error › error code 402 - privately publish scoped package
                                           ✔ npm › publish › no options set
                                                                             ✔ npm › publish › options.contents
                                                                                                                 ✔ npm › publish › options.tag
                                                                                                                                                ✔ npm › publish › options.otp
                                                                                                                                                                               ✔ npm › publish › options.publishScoped
                                       ✔ tasks › git-tasks › should fail when release branch is not specified, current branch is not the release branch, and publishing from any branch not permitted (274ms)
                              ✔ tasks › git-tasks › should fail when current branch is not the specified release branch and publishing from any branch not permitted
                                                                                                                                                                      ✔ tasks › git-tasks › should not fail when current branch not master and publishing from any branch permitted
                                                                                                    ✔ tasks › git-tasks › should fail when local working tree modified
                                                                                                                                                                        ✔ tasks › git-tasks › should not fail when no remote set up
                                                    ✔ tasks › git-tasks › should fail when remote history differs and changes are fetched
                                                                                                                                           ✔ tasks › git-tasks › should fail when remote has unfetched changes
                               ✔ tasks › git-tasks › checks should pass when publishing from master, working tree is clean and remote history not different
                                                                                                                                                             - [todo] tasks › prerequisite-tasks › should not fail if no collaborators
                                                       ✔ tasks › prerequisite-tasks › public-package published on npm registry: should fail when npm registry not pingable
                                                                                                                                                                            ✔ tasks › prerequisite-tasks › private package: should disable task pinging npm registry (6.7s)
                                                                                            ✔ tasks › prerequisite-tasks › external registry: should disable task pinging npm registry (7.1s)
              ✔ tasks › prerequisite-tasks › should fail when npm version does not match range in `package.json` (1s)
                                                                                                                       ✔ tasks › prerequisite-tasks › should fail when yarn version does not match range in `package.json` (951ms)
                                                   ✔ tasks › prerequisite-tasks › should fail when user is not authenticated at npm registry (1.6s)
                                                                                                                                                     ✔ tasks › prerequisite-tasks › should fail when user is not authenticated at external registry (280ms)
                                                                            ✔ tasks › prerequisite-tasks › private package: should disable task `verify user is authenticated` (7.5s)
      ✔ tasks › prerequisite-tasks › should fail when git version does not match range in `package.json` (1.3s)
                                                                                                                 ✔ tasks › prerequisite-tasks › should fail when git remote does not exist (952ms)
                   ✔ tasks › prerequisite-tasks › should fail when version is invalid (4.7s)
                                                                                              ✔ tasks › prerequisite-tasks › should fail when version is lower than latest version (5.2s)
          ✔ tasks › prerequisite-tasks › should fail when prerelease version of public package without dist tag given (5.9s)
                                                                                                                              ✔ tasks › prerequisite-tasks › should not fail when prerelease version of public package with dist tag given (7.8s)
                                                                  
                                                                    ✘ Timed out while running tests

                                                                                                     2 tests were pending in test/git-util/commit-log-from-revision.js

                                                                                                                                                                        ◌ git-util › commit-log-from-revision › returns single commit
                                                      ◌ git-util › commit-log-from-revision › returns multiple commits, from newest to oldest

                                                                                                                                               2 tests were pending in test/git-util/delete-tag.js

                   ◌ git-util › delete-tag › deletes given tag
                                                                ◌ git-util › delete-tag › deletes given tag from a large list

                                                                                                                               2 tests were pending in test/git-util/latest-tag-or-first-commit.js

                   ◌ git-util › latag-or-first-commit › one tag
                                                                 ◌ git-util › latag-or-first-commit › two tags

                                                                                                                2 tests were pending in test/git-util/latest-tag.js

                                                                                                                                                                     ◌ git-util › latag › returns latest tag
                             ◌ git-util › latag › returns latest tag - multiple set

                                                                                     2 tests were pending in test/git-util/new-files-since-last-release.js

                                                                                                                                                            ◌ git-util › new-files-since-last-release › returns files added since latest tag
                                                             ◌ git-util › new-files-since-last-release › no files

                                                                                                                   3 tests were pending in test/git-util/previous-tag-or-first-commit.js

         ◌ git-util › previous-tag-or-first-commit › one tag - fallback to first commit
                                                                                         ◌ git-util › previous-tag-or-first-commit › two tags
                                                                                                                                               ◌ git-util › previous-tag-or-first-commit › multiple tags

                         2 tests were pending in test/git-util/read-file-from-last-release.js

                                                                                               ◌ git-util › read-file-from-last-release › returns content of a given file
                                                                                                                                                                           ◌ git-util › read-file-from-last-release › fails if file not in previous release

                                                                            3 tests were pending in test/tasks/prerequisite-tasks.js

                                                                                                                                      ◌ tasks › prerequisite-tasks › should not fail when prerelease version of private package without dist tag given
                                                                       ◌ tasks › prerequisite-tasks › should fail when git tag already exists
                                                                                                                                               ◌ tasks › prerequisite-tasks › checks should pass

                 ✔ util › auto-group-list › one item
                                                      ✔ util › auto-group-list › mix of collapsed and expanded folders
                                                                                                                        ✔ util › join-list › one item
                                                                                                                                                       ✔ util › join-list › two items
      ✔ util › join-list › multiple items
                                           ✔ util › get-tag-version-prefix › no options passed
                                                                                                ✔ util › read-pkg › npPkg
                                                                                                                           ✔ util › read-pkg › npRootDir
                                                                                                                                                          ✔ util › read-pkg › without packagePath returns np package.json
                                          ✔ util › get-tag-version-prefix › returns preId postfix - yarn (1.1s)
                                                                                                                 ✔ util › get-tag-version-prefix › returns tag prefix - npm (1.2s)
   ✔ util › get-tag-version-prefix › defaults to "v" when command fails (1.2s)
                                                                                ✔ util › validate-engine-version-satisfies › node
                                                                                                                                   ✔ util › validate-engine-version-satisfies › npm
    ✔ util › validate-engine-version-satisfies › git
                                                      ✔ util › validate-engine-version-satisfies › yarn
                                                                                                         ✔ util › read-pkg › with packagePath (306ms)
                                                                                                                                                       ✔ util › get-pre-release-prefix › returns actual value (1.5s)
                                     ✔ util › get-pre-release-prefix › no options passed
                                                                                          ✔ util › read-pkg › no package.json (470ms)
                                                                                                                                       ✔ util › read-pkg › npRootDir is correct when process.cwd is different (1.1s)
                                     ✔ util › get-pre-release-prefix › returns preid postfix if set - npm (790ms)
                                                                                                                   ✔ util › get-pre-release-prefix › returns preid postfix if set - yarn (806ms)
                 ✔ util › get-pre-release-prefix › returns empty string if not set - npm (864ms)
                                                                                                  ✔ util › get-pre-release-prefix › returns empty string if not set - yarn (872ms)
   ✔ npm › util › check-ignore-strategy › no files w/ .npmignore (472ms)
                                                                          ✔ npm › util › check-ignore-strategy › files w/ .npmignore (471ms)
                                                                                                                                              ✔ npm › util › check-ignore-strategy › no files, no .npmignore (475ms)
                                     ✔ npm › util › check-ignore-strategy › files, no .npmignore (473ms)
                                                                                                          ✔ util › hyperlinks › linkifyIssues correctly links issues (3.6s)
                                                                                                                                                                             ✔ util › hyperlinks › linkifyIssues returns raw message if terminalLink is not supported (3.6s)
                                                                                             ✔ util › hyperlinks › linkifyCommit correctly links commits (3.6s)
                                                                                                                                                                 ✔ util › hyperlinks › linkifyCommit returns raw commit hash if url is not provided (3.6s)
                                                                           ✔ util › hyperlinks › linkifyCommit returns raw commit hash if terminalLink is not supported (3.6s)
                                                                                                                                                                                ✔ util › hyperlinks › linkifyCommitRange returns raw commitRange if url is not provided (3.7s)
                                                                                               ✔ util › hyperlinks › linkifyCommitRange returns raw commitRange if terminalLink is not supported (3.7s)
                        ✔ util › hyperlinks › linkifyIssues returns raw message if url is not provided (3.7s)
                                                                                                               ✔ util › hyperlinks › linkifyCommitRange correctly links commit range (3.7s)
            ✔ npm › util › check-connection › success (818ms)
                                                               ✔ npm › util › check-connection › fail (877ms)
                                                                                                               ✔ npm › util › is-external-registry › main
                                                                                                                                                           ✔ npm › util › collaborators › pkg.name not a string
                                ✔ util › get-new-dependencies › handles first time publish (no package.json in last release) (4.4s)
                                                                                                                                     ✔ util › get-new-dependencies › handles first time publish (no package.json in last release) - no deps (4.6s)
                                                                   ✔ npm › util › is-package-name-available › available (843ms)
                                                                                                                                 ✔ npm › util › is-package-name-available › unavailable (838ms)
                ✔ npm › util › is-package-name-available › bad package name (838ms)
                                                                                     ✔ npm › util › is-package-name-available › external registry (742ms)
                                                                                                                                                           ✔ npm › util › get-registry-url › yarn (1.1s)
                         ✔ npm › util › get-registry-url › npm (1.1s)
                                                                       ✔ npm › util › get-registry-url › external (1.1s)
                                                                                                                          ✔ npm › util › collaborators › npm v9.0.0 (1s)
                                                                                                                                                                          ✔ npm › util › collaborators › npm v9.0.0 - external registry (1s)
                                                             ✔ npm › util › collaborators › npm v9.0.0 - non-existent (1s)
                                                                                                                            ✔ npm › util › collaborators › npm v9.0.0 - error (1.1s)
     ✔ npm › util › prerelease-tags › packageName not a string
                                                                ✔ npm › util › packed-files › package.json files field - one file (2.4s)
                                                                                                                                          ✔ npm › util › packed-files › package.json files field - source dir (2.6s)
                                     ✔ npm › util › packed-files › package.json files field - leading slash (2.6s)
                                                                                                                    ✔ npm › util › packed-files › package.json files field - has readme and license (2.7s)
                           ✔ npm › util › packed-files › package.json files field - source and dist dirs (2.7s)
                                                                                                                 ✔ npm › util › packed-files › package.json files field and npmignore (2.7s)
             ✔ npm › util › packed-files › package.json main field not in files field (2.8s)
                                                                                              ✔ npm › util › packed-files › package.json files field and gitignore (2.8s)
                                                                                                                                                                           ✔ npm › util › packed-files › doesn't show files in .github (2.8s)
                                                              ✔ npm › util › packed-files › npmignore (2.9s)
                                                                                                              ✔ npm › util › packed-files › npmignore and gitignore (2.9s)
                                                                                                                                                                            ✔ npm › util › prerelease-tags › tags: latest (1.5s)
                                                 ✔ npm › util › verify-recent-npm-version › satisfied (1.5s)
                                                                                                              ✔ npm › util › verify-recent-npm-version › not satisfied (1.5s)
                                                                                                                                                                               ✔ npm › util › prerelease-tags › tags: latest, beta (1.5s)
                                                          ✔ npm › util › username › --registry flag (2.3s)
                                                                                                            ✔ npm › util › prerelease-tags › bad permission (code 403) - should throw (1.6s)
             ✔ npm › util › username › main (2.4s)
                                                    ✔ npm › util › prerelease-tags › non-existent (code 404) - should not throw (1.7s)
                                                                                                                                        ✔ npm › util › username › fails if not logged in (2.5s)
                ✔ npm › util › username › fails with authentication error (2.5s)
                                                                                  ✔ util › get-new-files › file `new` to package without tags added (9.5s)
                                                                                                                                                            ✔ ui › prompts › tags › choose next (734ms)
                        ✔ ui › prompts › tags › choose beta (742ms)
                                                                     ✔ ui › prompts › tags › choose custom (755ms)
                                                                                                                    ✔ ui › prompts › version › choose major (887ms)
                                                                                                                                                                     ✔ ui › prompts › tags › choose custom - validation (768ms)
                                                ✔ ui › prompts › version › choose minor (898ms)
                                                                                                 ✔ ui › prompts › tags › works for premajor (787ms)
                                                                                                                                                     ✔ ui › prompts › version › choose premajor (908ms)
                        ✔ ui › prompts › tags › works for prepatch (799ms)
                                                                            ✔ ui › prompts › version › choose preminor (921ms)
                                                                                                                                ✔ ui › prompts › tags › works for prerelease (803ms)
     ✔ ui › prompts › version › choose prepatch (934ms)
                                                         ✔ ui › prompts › tags › works for preminor (819ms)
                                                                                                             ✔ ui › prompts › version › choose prerelease (945ms)
                                                                                                                                                                   ✔ ui › prompts › version › choose custom (957ms)
                                    ✔ ui › prompts › version › choose patch (981ms)
                                                                                     ✔ ui › prompts › version › choose custom - validation (988ms)
                                                                                                                                                    ✔ npm › util › check-connection › timeout (15.8s)
                      
                        ✘ Timed out while running tests

                                                         7 tests were pending in test/ui/new-files-dependencies.js

                                                                                                                    ◌ ui › new-files-dependencies › unpublished
                                                                                                                                                                 ◌ ui › new-files-dependencies › unpublished and first time
                                            ◌ ui › new-files-dependencies › unpublished and dependencies
                                                                                                          ◌ ui › new-files-dependencies › first time
                                                                                                                                                      ◌ ui › new-files-dependencies › first time and dependencies
                                  ◌ ui › new-files-dependencies › dependencies
                                                                                ◌ ui › new-files-dependencies › unpublished and first time and dependencies

                                                                                                                                                             1 tests were pending in test/util/get-new-dependencies.js

                                       ◌ util › get-new-dependencies › reports new dependencies since last release

                                                                                                                    4 tests were pending in test/util/get-new-files.js

                                                                                                                                                                        ◌ util › get-new-files › files to package with tags added
                                                  ◌ util › get-new-files › files with long pathnames added
                                                                                                            ◌ util › get-new-files › no new files added
                                                                                                                                                         ◌ util › get-new-files › ignores .git and .github files

                                 ─

                                    215 tests passed
                                                      1 known failure
                                                                       2 tests todo
                                                                                     30 tests remained pending after a timeout
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

real	1m55.155s
user	1m36.458s
sys	0m16.015s
```