### PR TITLE
Fixes

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -73,9 +73,14 @@ const np = async (input = 'patch', options, {pkg, rootDir, isYarnBerry}) => {
 		const latestTag = await git.latestTag();
 		const versionInLatestTag = latestTag.slice(tagVersionPrefix.length);
 
+		async function getPkgVersion() {
+			const pkg = await util.readPkg(rootDir);
+			return pkg.version;
+		}
+
 		try {
 			// Verify that the package's version has been bumped before deleting the last tag and commit.
-			if (versionInLatestTag === util.readPkg(rootDir).version && versionInLatestTag !== pkg.version) {
+			if (versionInLatestTag === await getPkgVersion() && versionInLatestTag !== pkg.version) {
 				await git.deleteTag(latestTag);
 				await git.removeLastCommit();
 			}

--- a/source/util.js
+++ b/source/util.js
@@ -150,3 +150,8 @@ export const validateEngineVersionSatisfies = (engine, version) => {
 		throw new Error(`\`np\` requires ${engine} ${engineRange}`);
 	}
 };
+
+export async function getNpmPackageAccess(name) {
+	const {stdout} = await execa('npm', ['access', 'get', 'status', name, '--json']);
+	return JSON.parse(stdout)[name]; // Note: returns "private" for non-existent packages
+}


### PR DESCRIPTION
This PR is best reviewed commit-by-commit

## 1. [fix broken revert code after publish failure](https://github.com/sindresorhus/np/commit/a93422e53cf4ae0b9db9384d65ed47e480e8663c) 

it didn't work because of a missing await and `.pkg`

## 2. [make boolean logic easier to understand](https://github.com/sindresorhus/np/commit/dbd03e19fa58efb236c70ee08944910cb38d3103) 

because pkg.publishConfig will often be `undefined`, canBePublishedPublicly would short circuit to `undefined`, but `undefined` means `true` in inquirer's `when` option.
change this by always returning an explicit true or false.
this should not bring any changes.
also put isScoped(pkg.name) into the bool for consistency.

## 3 [fix yarn npm publish for scoped packages](https://github.com/sindresorhus/np/commit/1e5374f9faff0737a9a308e82d22073ff89e4aa0) 

this will make yarn berry `yarn npm publish` behave like `npm publish`:
`npm publish` on an already public scoped package will publish it gladly
however for `yarn npm publish`, even if the scoped package is already published publicly
we need to specify the `--access public` argument, or it will fail with 402 (Payment Required)
here I add a check (currently only for yarn berry) for whether the published version of the package is public,
and if so, set publishScoped to true (and don't ask for it)