### PR TITLE
Deduplicate `packageManager` creation

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -18,7 +18,7 @@ import {getPackagePublishArguments} from './npm/publish.js';
 import enable2fa, {getEnable2faArguments} from './npm/enable-2fa.js';
 import handleNpmError from './npm/handle-npm-error.js';
 import releaseTaskHelper from './release-task-helper.js';
-import {findLockfile, getPackageManagerConfig, printCommand} from './package-manager/index.js';
+import {findLockfile, printCommand} from './package-manager/index.js';
 import * as util from './util.js';
 import * as git from './git-util.js';
 import * as npm from './npm/util.js';
@@ -36,9 +36,7 @@ const exec = (command, arguments_, options) => {
 @param {import('./cli-implementation.js').Options} options
 @param {{package_: import('read-pkg').NormalizedPackageJson; rootDirectory: string}} context
 */
-const np = async (input = 'patch', options, {package_, rootDirectory}) => {
-	const packageManager = getPackageManagerConfig(rootDirectory, package_);
-
+const np = async (input = 'patch', {packageManager, ...options}, {package_, rootDirectory}) => {
 	// TODO: Remove sometime far in the future
 	if (options.skipCleanup) {
 		options.cleanup = false;

--- a/source/ui.js
+++ b/source/ui.js
@@ -5,7 +5,6 @@ import {htmlEscape} from 'escape-goat';
 import isScoped from 'is-scoped';
 import isInteractive from 'is-interactive';
 import {execa} from 'execa';
-import {getPackageManagerConfig} from './package-manager/index.js';
 import Version, {SEMVER_INCREMENTS} from './version.js';
 import * as util from './util.js';
 import * as git from './git-util.js';
@@ -125,16 +124,10 @@ const checkNewFilesAndDependencies = async (package_, rootDirectory) => {
 @param {import('./cli-implementation.js').CLI['flags']} options
 @param {{package_: import('read-pkg').NormalizedPackageJson; rootDirectory: string}} context
 */
-const ui = async (options, {package_, rootDirectory}) => {
+const ui = async ({packageManager, ...options}, {package_, rootDirectory}) => { // eslint-disable-line complexity
 	const oldVersion = package_.version;
 	const extraBaseUrls = ['gitlab.com'];
 	const repoUrl = package_.repository && githubUrlFromGit(package_.repository.url, {extraBaseUrls});
-
-	const packageManager = getPackageManagerConfig(rootDirectory, package_);
-
-	if (packageManager.throwOnExternalRegistry && npm.isExternalRegistry(package_)) {
-		throw new Error(`External registry is not yet supported with ${packageManager.id}.`);
-	}
 
 	const {stdout: registryUrl} = await execa(...packageManager.getRegistryCommand);
 	const releaseBranch = options.branch;

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import sinon from 'sinon';
 import esmock from 'esmock';
+import {npmConfig as packageManager} from '../source/package-manager/configs.js';
 import * as util from '../source/util.js';
 import np from '../source/index.js';
 
@@ -8,6 +9,7 @@ const defaultOptions = {
 	cleanup: true,
 	tests: true,
 	publish: true,
+	packageManager,
 	runPublish: true,
 	availability: {
 		isAvailable: false,

--- a/test/ui/new-files-dependencies.js
+++ b/test/ui/new-files-dependencies.js
@@ -4,6 +4,7 @@ import {execa} from 'execa';
 import {removePackageDependencies, updatePackage} from 'write-package';
 import stripAnsi from 'strip-ansi';
 import {readPackage} from 'read-pkg';
+import {npmConfig as packageManager} from '../../source/package-manager/configs.js';
 import {createIntegrationTest} from '../_helpers/integration-test.js';
 import {mockInquirer} from '../_helpers/mock-inquirer.js';
 
@@ -52,7 +53,7 @@ const createFixture = test.macro(async (t, package_, commands, expected) => {
 			},
 		});
 
-		await ui({runPublish: true, version: 'major', yarn: false}, {package_, rootDirectory: temporaryDirectory});
+		await ui({runPublish: true, version: 'major', packageManager}, {package_, rootDirectory: temporaryDirectory});
 		const logs = logsArray.join('').split('\n').map(log => stripAnsi(log));
 
 		const {unpublished, firstTime, dependencies} = expected;

--- a/test/ui/prompts/tags.js
+++ b/test/ui/prompts/tags.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import sinon from 'sinon';
+import {npmConfig as packageManager} from '../../../source/package-manager/configs.js';
 import {npPackage} from '../../../source/util.js';
 import {mockInquirer} from '../../_helpers/mock-inquirer.js';
 
@@ -25,6 +26,7 @@ const testUi = test.macro(async (t, {version, tags, answers}, assertions) => {
 	});
 
 	const results = await ui({
+		packageManager,
 		runPublish: true,
 		availability: {},
 	}, {

--- a/test/ui/prompts/version.js
+++ b/test/ui/prompts/version.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import sinon from 'sinon';
+import {npmConfig as packageManager} from '../../../source/package-manager/configs.js';
 import {mockInquirer} from '../../_helpers/mock-inquirer.js';
 
 const testUi = test.macro(async (t, {version, answers}, assertions) => {
@@ -20,6 +21,7 @@ const testUi = test.macro(async (t, {version, answers}, assertions) => {
 	});
 
 	const results = await ui({
+		packageManager,
 		runPublish: false,
 		availability: {},
 	}, {


### PR DESCRIPTION
Moves creation of `packageManager` up to the CLI, instead of independently resolving it in both the UI and the index.