### PR TITLE
Fix json output in some npm version

### DIFF
--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -138,7 +138,7 @@ export const checkIgnoreStrategy = async ({files}, rootDirectory) => {
 };
 
 export const getFilesToBePacked = async rootDirectory => {
-	const {stdout} = await execa('npm', ['pack', '--dry-run', '--json'], {cwd: rootDirectory});
+	const {stdout} = await execa('npm', ['pack', '--dry-run', '--json', '--silent'], {cwd: rootDirectory});
 
 	const {files} = JSON.parse(stdout).at(0);
 	return files.map(file => file.path);

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -140,6 +140,10 @@ export const checkIgnoreStrategy = async ({files}, rootDirectory) => {
 export const getFilesToBePacked = async rootDirectory => {
 	const {stdout} = await execa('npm', ['pack', '--dry-run', '--json', '--silent'], {cwd: rootDirectory});
 
-	const {files} = JSON.parse(stdout).at(0);
-	return files.map(file => file.path);
+	try {
+		const {files} = JSON.parse(stdout).at(0);
+		return files.map(file => file.path);
+	} catch (cause) {
+		throw new Error('Failed to parse output of npm pack', { cause });
+	}
 };

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -143,7 +143,7 @@ export const getFilesToBePacked = async rootDirectory => {
 	try {
 		const {files} = JSON.parse(stdout).at(0);
 		return files.map(file => file.path);
-	} catch (cause) {
-		throw new Error('Failed to parse output of npm pack', { cause });
+	} catch (error) {
+		throw new Error('Failed to parse output of npm pack', {cause: error});
 	}
 };


### PR DESCRIPTION
I was having an issue with `np` on `npm` version `10.5.0` and when digging into it I found that the `npm pack` command was outputting some "helpful" notes prior to the JSON.

I tried adding a `--silent` to the command, and that fixed remove the "helpfulness".

Apart from doing that, this PR also wraps the original exception in a new error that explains what kind of JSON-parsing that's failing – as that can make it a bit more easy to understand why it suddenly started failing.

My `npm` version `10.5.0`:

```
❯ npm pack --dry-run --json                                 

> @voxpelli/typed-utils@1.3.0 prepare
> husky

[
  {
    "id": "@voxpelli/typed-utils@1.3.0",
    "name": "@voxpelli/typed-utils",
```