### PR TITLE
pnpm: use npm for tag-version-prefix

### DIFF
--- a/source/package-manager/configs.js
+++ b/source/package-manager/configs.js
@@ -17,7 +17,7 @@ export const pnpmConfig = {
 	installCommand: ['pnpm', ['install']],
 	installCommandNoLockfile: ['pnpm', ['install']],
 	versionCommand: version => ['pnpm', ['version', version]],
-	// pnpm config doesn't have `v` as a default tag version prefix, so to get consistent default behavior, use npm.
+	// Pnpm config doesn't have `v` as a default tag version prefix, so to get consistent default behavior, use npm.
 	tagVersionPrefixCommand: ['npm', ['config', 'get', 'tag-version-prefix']],
 	getRegistryCommand: ['pnpm', ['config', 'get', 'registry']],
 	lockfiles: ['pnpm-lock.yaml'],

--- a/source/package-manager/configs.js
+++ b/source/package-manager/configs.js
@@ -17,7 +17,8 @@ export const pnpmConfig = {
 	installCommand: ['pnpm', ['install']],
 	installCommandNoLockfile: ['pnpm', ['install']],
 	versionCommand: version => ['pnpm', ['version', version]],
-	tagVersionPrefixCommand: ['pnpm', ['config', 'get', 'tag-version-prefix']],
+	// pnpm config doesn't have `v` as a default tag version prefix, so to get consistent default behavior, use npm.
+	tagVersionPrefixCommand: ['npm', ['config', 'get', 'tag-version-prefix']],
 	getRegistryCommand: ['pnpm', ['config', 'get', 'registry']],
 	lockfiles: ['pnpm-lock.yaml'],
 };


### PR DESCRIPTION
Fixes half of https://github.com/sindresorhus/np/issues/738

Does not fix the bug that creates two separate tags when the prefix is missing, but makes sure that most users, who aren't interested in customising the tag, get the same `v` prefix on pnpm as they do on npm and yarn.