### PR TITLE
Fix publish otp for yarn berry

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -14,7 +14,7 @@ import {asyncExitHook} from 'exit-hook';
 import logSymbols from 'log-symbols';
 import prerequisiteTasks from './prerequisite-tasks.js';
 import gitTasks from './git-tasks.js';
-import {getPackagePublishArguments} from './npm/publish.js';
+import {getPackagePublishArguments, runPublish} from './npm/publish.js';
 import enable2fa, {getEnable2faArguments} from './npm/enable-2fa.js';
 import handleNpmError from './npm/handle-npm-error.js';
 import releaseTaskHelper from './release-task-helper.js';
@@ -179,12 +179,12 @@ const np = async (input = 'patch', {packageManager, ...options}, {package_, root
 				task(context, task) {
 					let hasError = false;
 
-					return from(execa(...getPublishCommand(options)))
+					return from(runPublish(getPublishCommand(options)))
 						.pipe(
 							catchError(error => handleNpmError(error, task, otp => {
 								context.otp = otp;
 
-								return execa(...getPublishCommand({...options, otp}));
+								return runPublish(getPublishCommand({...options, otp}));
 							})),
 						)
 						.pipe(

--- a/source/npm/handle-npm-error.js
+++ b/source/npm/handle-npm-error.js
@@ -10,7 +10,7 @@ const handleNpmError = (error, task, message, executor) => {
 
 	// `one-time pass` is for npm and `Two factor authentication` is for Yarn.
 	if (
-		error.stderr.includes('one-time pass') // npm
+		error.stderr.includes('one-time pass') // Npm
 		|| error.stdout.includes('Two factor authentication') // Yarn v1
 		|| error.stdout.includes('One-time password:') // Yarn berry
 	) {

--- a/source/npm/handle-npm-error.js
+++ b/source/npm/handle-npm-error.js
@@ -9,7 +9,11 @@ const handleNpmError = (error, task, message, executor) => {
 	}
 
 	// `one-time pass` is for npm and `Two factor authentication` is for Yarn.
-	if (error.stderr.includes('one-time pass') || error.stdout.includes('Two factor authentication')) {
+	if (
+		error.stderr.includes('one-time pass') // npm
+		|| error.stdout.includes('Two factor authentication') // Yarn v1
+		|| error.stdout.includes('One-time password:') // Yarn berry
+	) {
 		const {title} = task;
 		task.title = `${title} ${chalk.yellow('(waiting for input…)')}`;
 

--- a/source/npm/publish.js
+++ b/source/npm/publish.js
@@ -19,3 +19,16 @@ export const getPackagePublishArguments = options => {
 
 	return arguments_;
 };
+
+export function runPublish(args) {
+	const cp = execa(...args);
+
+	cp.stdout.on('data', chunk => {
+		// https://github.com/yarnpkg/berry/blob/a3e5695186f2aec3a68810acafc6c9b1e45191da/packages/plugin-npm/sources/npmHttpUtils.ts#L541
+		if (chunk.toString('utf8').includes('One-time password:')) {
+			cp.kill();
+		}
+	})
+
+	return cp;
+}

--- a/source/npm/publish.js
+++ b/source/npm/publish.js
@@ -1,3 +1,5 @@
+import {execa} from 'execa';
+
 export const getPackagePublishArguments = options => {
 	const arguments_ = ['publish'];
 
@@ -20,15 +22,15 @@ export const getPackagePublishArguments = options => {
 	return arguments_;
 };
 
-export function runPublish(args) {
-	const cp = execa(...args);
+export function runPublish(arguments_) {
+	const cp = execa(...arguments_);
 
 	cp.stdout.on('data', chunk => {
 		// https://github.com/yarnpkg/berry/blob/a3e5695186f2aec3a68810acafc6c9b1e45191da/packages/plugin-npm/sources/npmHttpUtils.ts#L541
 		if (chunk.toString('utf8').includes('One-time password:')) {
 			cp.kill();
 		}
-	})
+	});
 
 	return cp;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -62,7 +62,10 @@ test('skip enabling 2FA if the package exists', async t => {
 			verifyWorkingTreeIsClean: sinon.stub(),
 		},
 		'../source/npm/enable-2fa.js': enable2faStub,
-		'../source/npm/publish.js': sinon.stub().returns({pipe: sinon.stub()}),
+		'../source/npm/publish.js': {
+			getPackagePublishArguments: sinon.stub().returns([]),
+			runPublish: sinon.stub().returns(fakeExecaReturn()),
+		},
 	});
 
 	await t.notThrowsAsync(npMock('1.0.0', {
@@ -91,7 +94,10 @@ test('skip enabling 2FA if the `2fa` option is false', async t => {
 			verifyWorkingTreeIsClean: sinon.stub(),
 		},
 		'../source/npm/enable-2fa.js': enable2faStub,
-		'../source/npm/publish.js': sinon.stub().returns({pipe: sinon.stub()}),
+		'../source/npm/publish.js': {
+			getPackagePublishArguments: sinon.stub().returns([]),
+			runPublish: sinon.stub().returns(fakeExecaReturn()),
+		},
 	});
 
 	await t.notThrowsAsync(npMock('1.0.0', {


### PR DESCRIPTION
symptom: hangs forever here:

```
  ✔ Prerequisite check
  ✔ Git
  ✔ Installing dependencies using yarn-berry
  ✔ Running tests
  ✔ Bumping version
  ⠦ Publishing package
```

I aborted it and tried to run the command manually and I can see that it prompts for a OTP on stdout:
```
yarn npm publish
➤ YN0000: LICENSE
➤ YN0000: README.md
➤ YN0000: index.js
➤ YN0000: package.json
✖ One-time password: · 
```

Looking at the `np` otp implementation it seems that npm and yarn v1 will exit with an error when an OTP is encountered:
https://github.com/sindresorhus/np/blob/6ee23e5c0160b2991000260cc864c15d649b04df/source/npm/handle-npm-error.js#L12

however yarn berry doesn't exit, it just prints the OTP prompt and hangs forever. this PR will help kill it off so that OTP can be prompted to the user and then re-run the cmd. not the cleanest but it works.

kind of related to #725