### PR TITLE
fix: npm 10 bug with npm pack; issue 740

### DIFF
--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -141,6 +141,7 @@ export const getFilesToBePacked = async rootDirectory => {
 	const {stdout} = await execa('npm', ['pack', '--dry-run', '--json', '--silent'], {cwd: rootDirectory});
 
 	try {
+		// TODO: Remove this once [npm/cli#7354](https://github.com/npm/cli/issues/7354) is resolved.
 		const cleanStdout = stdout.replace(/^[^[]*\[/, '[').trim();
 		const {files} = JSON.parse(cleanStdout).at(0);
 		return files.map(file => file.path);

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -141,7 +141,8 @@ export const getFilesToBePacked = async rootDirectory => {
 	const {stdout} = await execa('npm', ['pack', '--dry-run', '--json', '--silent'], {cwd: rootDirectory});
 
 	try {
-		const {files} = JSON.parse(stdout).at(0);
+		const cleanStdout = stdout.replace(/^[^[]*\[/, '[').trim();
+		const {files} = JSON.parse(cleanStdout).at(0);
 		return files.map(file => file.path);
 	} catch (error) {
 		throw new Error('Failed to parse output of npm pack', {cause: error});


### PR DESCRIPTION
Fixes #740 

Anyone using `np` with newer versions of Node.js and `npm >= 10` is probably running into this issue. This PR just sanitizes the `stdout` from `npm pack` to look for the first `[` character to start parsing the output JSON array, which should be backwards compatible with previous functionality.