### PR TITLE
Fix np with pnpm and --any-branch or --branch

### DIFF
--- a/source/package-manager/configs.js
+++ b/source/package-manager/configs.js
@@ -17,8 +17,10 @@ export const pnpmConfig = {
 	installCommand: ['pnpm', ['install']],
 	installCommandNoLockfile: ['pnpm', ['install']],
 	versionCommand: version => ['pnpm', ['version', version]],
-	// Pnpm config doesn't have `v` as a default tag version prefix, so to get consistent default behavior, use npm.
+	// pnpm config doesn't have `v` as a default tag version prefix, so to get consistent default behavior, use npm.
 	tagVersionPrefixCommand: ['npm', ['config', 'get', 'tag-version-prefix']],
+	// Disable duplicated pnpm Git checks
+	publishCommand: arguments_ => ['pnpm', [...arguments_, '--no-git-checks']],
 	getRegistryCommand: ['pnpm', ['config', 'get', 'registry']],
 	lockfiles: ['pnpm-lock.yaml'],
 };

--- a/source/package-manager/configs.js
+++ b/source/package-manager/configs.js
@@ -17,7 +17,7 @@ export const pnpmConfig = {
 	installCommand: ['pnpm', ['install']],
 	installCommandNoLockfile: ['pnpm', ['install']],
 	versionCommand: version => ['pnpm', ['version', version]],
-	// pnpm config doesn't have `v` as a default tag version prefix, so to get consistent default behavior, use npm.
+	// By default, pnpm config returns `undefined` instead of `v` for tag-version-prefix, so for consistent default behavior, use npm.
 	tagVersionPrefixCommand: ['npm', ['config', 'get', 'tag-version-prefix']],
 	// Disable duplicated pnpm Git checks
 	publishCommand: arguments_ => ['pnpm', [...arguments_, '--no-git-checks']],


### PR DESCRIPTION
<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->

Fixes the hanging of the `Publishing package` step caused by pnpm checking Git branches and waiting for stdin (this message is not visible, `np` just hangs on `Publishing package` on a non-`main`/`master` branch):

```
pnpm publish
? You're on branch "renovate/eslint-monorepo" but your "publish-branch" is set to "master|main". Do you want to continue? (y/N) › false
```

This disables the Git checks via the [`--no-git-checks` option](https://pnpm.io/cli/publish#--no-git-checks)

cc @mmkal