### PR TITLE
Remove double space in release body

### DIFF
--- a/source/ui.js
+++ b/source/ui.js
@@ -65,7 +65,7 @@ const printCommitLog = async (repoUrl, registryUrl, fromLatestTag, releaseBranch
 	}).join('\n');
 
 	const releaseNotes = nextTag => commits.map(commit =>
-		`- ${htmlEscape(commit.message)}  ${commit.id}`,
+		`- ${htmlEscape(commit.message)} ${commit.id}`,
 	).join('\n') + `\n\n${repoUrl}/compare/${revision}...${nextTag}`;
 
 	const commitRange = util.linkifyCommitRange(repoUrl, commitRangeText);


### PR DESCRIPTION
Don't really mind either way. I just can't tell if its a typo or not.

I opened it as a PR in case it really is, but I can also think of reasons why not.