### PR TITLE
Allow `publishConfig.registry` to be npm default registry when using Yarn berry

### DIFF
--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -127,12 +127,7 @@ async function getOptions() {
 
 	const packageManager = getPackageManagerConfig(rootDirectory, package_);
 
-	if (
-		packageManager.throwOnExternalRegistry
-		&& npm.isExternalRegistry(package_)
-		// NPM default registry https://github.com/npm/pneumatic-tubes/blob/1064fbb461464cc0fe18bd2790a176aa92bd63fd/index.js#L35
-		&& package_.publishConfig.registry !== 'https://registry.npmjs.org'
-	) {
+	if (packageManager.throwOnExternalRegistry && npm.isExternalRegistry(package_)) {
 		throw new Error(`External registry is not yet supported with ${packageManager.id}.`);
 	}
 

--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -127,7 +127,12 @@ async function getOptions() {
 
 	const packageManager = getPackageManagerConfig(rootDirectory, package_);
 
-	if (packageManager.throwOnExternalRegistry && npm.isExternalRegistry(package_)) {
+	if (
+		packageManager.throwOnExternalRegistry
+		&& npm.isExternalRegistry(package_)
+		// NPM default registry https://github.com/npm/pneumatic-tubes/blob/1064fbb461464cc0fe18bd2790a176aa92bd63fd/index.js#L35
+		&& package_.publishConfig.registry !== 'https://registry.npmjs.org'
+	) {
 		throw new Error(`External registry is not yet supported with ${packageManager.id}.`);
 	}
 

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -47,7 +47,7 @@ const NPM_DEFAULT_REGISTRIES = new Set([
 	// https://docs.npmjs.com/cli/v10/using-npm/registry
 	'https://registry.npmjs.org',
 	// https://docs.npmjs.com/cli/v10/commands/npm-profile#registry
-	'https://registry.npmjs.org/'
+	'https://registry.npmjs.org/',
 ]);
 export const isExternalRegistry = package_ => {
 	const registry = package_.publishConfig?.registry;

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -43,11 +43,15 @@ export const username = async ({externalRegistry}) => {
 	}
 };
 
-// NPM default registry https://github.com/npm/pneumatic-tubes/blob/1064fbb461464cc0fe18bd2790a176aa92bd63fd/index.js#L35
-const NPM_DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+const NPM_DEFAULT_REGISTRIES = new Set([
+	// https://docs.npmjs.com/cli/v10/using-npm/registry
+	'https://registry.npmjs.org',
+	// https://docs.npmjs.com/cli/v10/commands/npm-profile#registry
+	'https://registry.npmjs.org/'
+]);
 export const isExternalRegistry = package_ => {
 	const registry = package_.publishConfig?.registry;
-	return typeof registry === 'string' && registry !== NPM_DEFAULT_REGISTRY;
+	return typeof registry === 'string' && !NPM_DEFAULT_REGISTRIES.has(registry);
 };
 
 export const collaborators = async package_ => {

--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -43,7 +43,12 @@ export const username = async ({externalRegistry}) => {
 	}
 };
 
-export const isExternalRegistry = package_ => typeof package_.publishConfig?.registry === 'string';
+// NPM default registry https://github.com/npm/pneumatic-tubes/blob/1064fbb461464cc0fe18bd2790a176aa92bd63fd/index.js#L35
+const NPM_DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+export const isExternalRegistry = package_ => {
+	const registry = package_.publishConfig?.registry;
+	return typeof registry === 'string' && registry !== NPM_DEFAULT_REGISTRY;
+};
 
 export const collaborators = async package_ => {
 	const packageName = package_.name;

--- a/test/npm/util/is-external-registry.js
+++ b/test/npm/util/is-external-registry.js
@@ -8,4 +8,5 @@ test('main', t => {
 	t.false(npm.isExternalRegistry({publishConfig: {registry: true}}));
 	t.false(npm.isExternalRegistry({publishConfig: 'not an object'}));
 	t.false(npm.isExternalRegistry({publishConfig: {registry: 'https://registry.npmjs.org'}}));
+	t.false(npm.isExternalRegistry({publishConfig: {registry: 'https://registry.npmjs.org/'}}));
 });

--- a/test/npm/util/is-external-registry.js
+++ b/test/npm/util/is-external-registry.js
@@ -7,4 +7,5 @@ test('main', t => {
 	t.false(npm.isExternalRegistry({name: 'foo'}));
 	t.false(npm.isExternalRegistry({publishConfig: {registry: true}}));
 	t.false(npm.isExternalRegistry({publishConfig: 'not an object'}));
+	t.false(npm.isExternalRegistry({publishConfig: {registry: 'https://registry.npmjs.org'}}));
 });


### PR DESCRIPTION
Allow `publishConfig.registry` to be `'https://registry.npmjs.org'`

~Though I uses `https://registry.npmjs.org/`, but the default value does not include the trailing slash, so I'm going to change my package.json and live with it. 😄~ Turns out both used in npm docs.

~I didn't change `isExternalRegistry` utility, since I found it's used for different purpose~ https://github.com/sindresorhus/np/pull/750#issuecomment-2230575776

Fixes #749
<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
