### PR TITLE
Update dependency `del` to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"chalk": "^5.3.0",
 		"chalk-template": "^1.1.0",
 		"cosmiconfig": "^8.3.6",
-		"del": "^7.1.0",
+		"del": "^8.0.0",
 		"escape-goat": "^4.0.0",
 		"escape-string-regexp": "^5.0.0",
 		"execa": "^8.0.1",


### PR DESCRIPTION
`del` is updated to get rid of the `rimraf` and `glob` deprecation warnings

closes #757

<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
