### PR TITLE
Change code style badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# np [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/xojs/xo)
+# np [![XO code style](https://shields.io/badge/code_style-5ed9c7?logo=xo&labelColor=gray&logoSize=auto&logoWidth=20)](https://github.com/xojs/xo)
 
 > A better `npm publish`
 


### PR DESCRIPTION
Change the XO code style badge to the [official version](https://github.com/xojs/xo?tab=readme-ov-file#badge).

Before:
<img width="155" alt="image" src="https://github.com/user-attachments/assets/e893810a-6d4e-47b1-ac78-f0fb79832fdb" />

After:
<img width="158" alt="image" src="https://github.com/user-attachments/assets/5faa98fa-fcef-471e-9627-d1210469d770" />
