### PR TITLE
fix: rm terminalLink.isSupported checks

### DIFF
--- a/source/util.js
+++ b/source/util.js
@@ -34,7 +34,7 @@ const _npRootDirectory = fileURLToPath(new URL('..', import.meta.url));
 export const {package_: npPackage, rootDirectory: npRootDirectory} = await readPackage(_npRootDirectory);
 
 export const linkifyIssues = (url, message) => {
-	if (!(url && terminalLink.isSupported)) {
+	if (!url) {
 		return message;
 	}
 
@@ -50,7 +50,7 @@ export const linkifyIssues = (url, message) => {
 };
 
 export const linkifyCommit = (url, commit) => {
-	if (!(url && terminalLink.isSupported)) {
+	if (!url) {
 		return commit;
 	}
 
@@ -58,7 +58,7 @@ export const linkifyCommit = (url, commit) => {
 };
 
 export const linkifyCommitRange = (url, commitRange) => {
-	if (!(url && terminalLink.isSupported)) {
+	if (!url) {
 		return commitRange;
 	}
 

--- a/source/util.js
+++ b/source/util.js
@@ -4,13 +4,20 @@ import path from 'node:path';
 import {readPackageUp} from 'read-package-up';
 import {parsePackage} from 'read-pkg';
 import issueRegex from 'issue-regex';
-import terminalLink from 'terminal-link';
+import createTerminalLink from 'terminal-link';
 import {execa} from 'execa';
 import pMemoize from 'p-memoize';
 import chalk from 'chalk';
 import Version from './version.js';
 import * as git from './git-util.js';
 import * as npm from './npm/util.js';
+
+// TODO[terminal-link@>4.0.0]: remove terminal-link wrapper with fallback after https://github.com/sindresorhus/terminal-link/issues/18 is fixed
+/** @type {(text: string, url: string, options?: import('terminal-link').Options) => string} */
+const terminalLink = (text, url, options) => createTerminalLink(text, url, {
+	fallback: (text, url) => `${text} ( ${url} )`,
+	...options,
+});
 
 export const assert = (condition, message) => {
 	if (!condition) {

--- a/test/util/hyperlinks.js
+++ b/test/util/hyperlinks.js
@@ -36,7 +36,7 @@ test('linkifyIssues returns raw message if terminalLink is not supported', verif
 	linksSupported: false,
 }, ({t, util: {linkifyIssues}}) => {
 	const message = 'Commit message - fixes #6';
-	t.is(linkifyIssues(MOCK_REPO_URL, message), `${message} (\u200B${MOCK_REPO_URL}/issues/6\u200B)`);
+	t.is(linkifyIssues(MOCK_REPO_URL, message), `${message} ( ${MOCK_REPO_URL}/issues/6 )`);
 });
 
 test('linkifyCommit correctly links commits', verifyLinks, {
@@ -54,7 +54,7 @@ test('linkifyCommit returns raw commit hash if url is not provided', verifyLinks
 test('linkifyCommit returns raw commit hash if terminalLink is not supported', verifyLinks, {
 	linksSupported: false,
 }, ({t, util: {linkifyCommit}}) => {
-	t.is(linkifyCommit(MOCK_REPO_URL, MOCK_COMMIT_HASH), `${MOCK_COMMIT_HASH} (\u200B${MOCK_REPO_URL}/commit/${MOCK_COMMIT_HASH}\u200B)`);
+	t.is(linkifyCommit(MOCK_REPO_URL, MOCK_COMMIT_HASH), `${MOCK_COMMIT_HASH} ( ${MOCK_REPO_URL}/commit/${MOCK_COMMIT_HASH} )`);
 });
 
 test('linkifyCommitRange returns raw commitRange if url is not provided', verifyLinks, {
@@ -66,7 +66,7 @@ test('linkifyCommitRange returns raw commitRange if url is not provided', verify
 test('linkifyCommitRange returns raw commitRange if terminalLink is not supported', verifyLinks, {
 	linksSupported: false,
 }, ({t, util: {linkifyCommitRange}}) => {
-	t.is(linkifyCommitRange(MOCK_REPO_URL, MOCK_COMMIT_RANGE), `${MOCK_COMMIT_RANGE} (\u200B${MOCK_REPO_URL}/compare/${MOCK_COMMIT_RANGE}\u200B)`);
+	t.is(linkifyCommitRange(MOCK_REPO_URL, MOCK_COMMIT_RANGE), `${MOCK_COMMIT_RANGE} ( ${MOCK_REPO_URL}/compare/${MOCK_COMMIT_RANGE} )`);
 });
 
 test('linkifyCommitRange correctly links commit range', verifyLinks, {

--- a/test/util/hyperlinks.js
+++ b/test/util/hyperlinks.js
@@ -36,7 +36,7 @@ test('linkifyIssues returns raw message if terminalLink is not supported', verif
 	linksSupported: false,
 }, ({t, util: {linkifyIssues}}) => {
 	const message = 'Commit message - fixes #6';
-	t.is(linkifyIssues(MOCK_REPO_URL, message), message);
+	t.is(linkifyIssues(MOCK_REPO_URL, message), `${message} (\u200B${MOCK_REPO_URL}/issues/6\u200B)`);
 });
 
 test('linkifyCommit correctly links commits', verifyLinks, {
@@ -54,7 +54,7 @@ test('linkifyCommit returns raw commit hash if url is not provided', verifyLinks
 test('linkifyCommit returns raw commit hash if terminalLink is not supported', verifyLinks, {
 	linksSupported: false,
 }, ({t, util: {linkifyCommit}}) => {
-	t.is(linkifyCommit(MOCK_REPO_URL, MOCK_COMMIT_HASH), MOCK_COMMIT_HASH);
+	t.is(linkifyCommit(MOCK_REPO_URL, MOCK_COMMIT_HASH), `${MOCK_COMMIT_HASH} (\u200B${MOCK_REPO_URL}/commit/${MOCK_COMMIT_HASH}\u200B)`);
 });
 
 test('linkifyCommitRange returns raw commitRange if url is not provided', verifyLinks, {
@@ -66,7 +66,7 @@ test('linkifyCommitRange returns raw commitRange if url is not provided', verify
 test('linkifyCommitRange returns raw commitRange if terminalLink is not supported', verifyLinks, {
 	linksSupported: false,
 }, ({t, util: {linkifyCommitRange}}) => {
-	t.is(linkifyCommitRange(MOCK_REPO_URL, MOCK_COMMIT_RANGE), MOCK_COMMIT_RANGE);
+	t.is(linkifyCommitRange(MOCK_REPO_URL, MOCK_COMMIT_RANGE), `${MOCK_COMMIT_RANGE} (\u200B${MOCK_REPO_URL}/compare/${MOCK_COMMIT_RANGE}\u200B)`);
 });
 
 test('linkifyCommitRange correctly links commit range', verifyLinks, {


### PR DESCRIPTION
They're not needed - the terminal-link package checks this internally and formats the URL using parentheses and zero-width spaces. As it is the logic is dropping the URL in terminals like VSCode's/Cursor's terminal.

<img width="470" alt="image" src="https://github.com/user-attachments/assets/63c168ff-ea4a-415f-8cf0-0bd2eedfebbb" />

Can't rely on terminal-link as-is, though, because of https://github.com/sindresorhus/terminal-link/issues/18

I just set the fallback to be `${text} ( ${url} )` (i.e. using regular spaces instead of zero-width, because many UIs include the trailing zero-width space which breaks the URL clickability/copyability - see the long list of references on that issue, from redwood, shopify cli, warp etc. etc.)

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/f4237e28-9da6-4dba-9adf-0c00d7d50c8d" />


<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
