### PR TITLE
Replace fetch with ls-remote for performance

### DIFF
--- a/source/git-util.js
+++ b/source/git-util.js
@@ -224,28 +224,14 @@ export const defaultBranch = async () => {
 	throw new Error('Could not infer the default Git branch. Please specify one with the --branch flag or with a np config.');
 };
 
-const tagExistsOnRemote = async tagName => {
-	try {
-		const {stdout: revInfo} = await execa('git', ['rev-parse', '--quiet', '--verify', `refs/tags/${tagName}`]);
-
-		if (revInfo) {
-			return true;
-		}
-
-		return false;
-	} catch (error) {
-		// Command fails with code 1 and no output if the tag does not exist, even though `--quiet` is provided
-		// https://github.com/sindresorhus/np/pull/73#discussion_r72385685
-		if (error.stdout === '' && error.stderr === '') {
-			return false;
-		}
-
-		throw error;
-	}
+const tagExistsOnRemote = async (tagName, remote) => {
+	// Note: we query the remote directly (previously this did a full git fetch)
+	const {stdout} = await execa('git', ['ls-remote', '--tags', remote ?? 'origin', tagName], {stdin: 'inherit', timeout: gitNetworkTimeout});
+	return stdout.trim().length > 0;
 };
 
-export const verifyTagDoesNotExistOnRemote = async tagName => {
-	if (await tagExistsOnRemote(tagName)) {
+export const verifyTagDoesNotExistOnRemote = async (tagName, remote) => {
+	if (await tagExistsOnRemote(tagName, remote)) {
 		throw new Error(`Git tag \`${tagName}\` already exists.`);
 	}
 };

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -125,11 +125,9 @@ const prerequisiteTasks = (input, package_, options, {packageManager, rootDirect
 		{
 			title: 'Check git tag existence',
 			async task() {
-				await git.fetch();
-
 				const tagPrefix = await util.getTagVersionPrefix(packageManager);
 
-				await git.verifyTagDoesNotExistOnRemote(`${tagPrefix}${newVersion}`);
+				await git.verifyTagDoesNotExistOnRemote(`${tagPrefix}${newVersion}`, options.remote);
 			},
 		},
 	];

--- a/test/_helpers/stub-execa.js
+++ b/test/_helpers/stub-execa.js
@@ -11,7 +11,6 @@ const defaultCommands = [
 	{command: 'npm view --json test engines', stdout: ''},
 	{command: 'git version', stdout: 'git version 2.40.0'},
 	{command: 'git ls-remote origin HEAD', stdout: 'abc123\tHEAD'},
-	{command: 'git fetch', stdout: ''},
 	{command: 'git config --get tag.gpgSign', stdout: ''},
 ];
 

--- a/test/git-util/verify-tag-does-not-exist-on-remote.js
+++ b/test/git-util/verify-tag-does-not-exist-on-remote.js
@@ -5,8 +5,8 @@ import {_createFixture} from '../_helpers/stub-execa.js';
 const createFixture = _createFixture('../../source/git-util.js', import.meta.url);
 
 test('exists', createFixture, [{
-	command: 'git rev-parse --quiet --verify refs/tags/v0.0.0',
-	stdout: '123456789', // Some hash
+	command: 'git ls-remote --tags origin v0.0.0',
+	stdout: 'foobar\trefs/tags/v0.0.0',
 }], async ({t, testedModule: {verifyTagDoesNotExistOnRemote}}) => {
 	await t.throwsAsync(
 		verifyTagDoesNotExistOnRemote('v0.0.0'),
@@ -15,10 +15,18 @@ test('exists', createFixture, [{
 });
 
 test('does not exist', createFixture, [{
-	command: 'git rev-parse --quiet --verify refs/tags/v0.0.0',
-	exitCode: 1,
-	stderr: '',
+	command: 'git ls-remote --tags origin v0.0.0',
 	stdout: '',
 }], async ({t, testedModule: {verifyTagDoesNotExistOnRemote}}) => {
 	await t.notThrowsAsync(verifyTagDoesNotExistOnRemote('v0.0.0'));
+});
+
+test('exists on custom remote', createFixture, [{
+	command: 'git ls-remote --tags upstream v0.0.0',
+	stdout: 'foobar\trefs/tags/v0.0.0',
+}], async ({t, testedModule: {verifyTagDoesNotExistOnRemote}}) => {
+	await t.throwsAsync(
+		verifyTagDoesNotExistOnRemote('v0.0.0', 'upstream'),
+		{message: 'Git tag `v0.0.0` already exists.'},
+	);
 });

--- a/test/tasks/prerequisite-tasks.js
+++ b/test/tasks/prerequisite-tasks.js
@@ -45,7 +45,7 @@ test.serial('private package: should disable task pinging npm registry', createF
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+	command: 'git ls-remote --tags origin v2.0.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('2.0.0', {name: 'test', version: '1.0.0', private: true}, {}, {packageManager: npmConfig})));
@@ -63,7 +63,7 @@ test.serial('external registry: should disable task pinging npm registry', creat
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+	command: 'git ls-remote --tags origin v2.0.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('2.0.0', {name: 'test', version: '1.0.0', publishConfig: {registry: 'http://my.io'}}, {}, {packageManager: npmConfig})));
@@ -77,7 +77,7 @@ test.serial('should fail when npm version does not match range in `package.json`
 		stdout: '6.0.0',
 	},
 	{
-		command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+		command: 'git ls-remote --tags origin v2.0.0',
 		stdout: '',
 	},
 ], async ({t, testedModule: prerequisiteTasks}) => {
@@ -97,7 +97,7 @@ test.serial('should fail when yarn version does not match range in `package.json
 		stdout: '1.0.0',
 	},
 	{
-		command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+		command: 'git ls-remote --tags origin v2.0.0',
 		stdout: '',
 	},
 ], async ({t, testedModule: prerequisiteTasks}) => {
@@ -186,7 +186,7 @@ test.serial('private package: should disable task `verify user is authenticated`
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+	command: 'git ls-remote --tags origin v2.0.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	process.env.NODE_ENV = 'P';
@@ -289,7 +289,7 @@ test.serial('should not fail when prerelease version of public package with dist
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+	command: 'git ls-remote --tags origin v2.0.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('2.0.0-1', {name: 'test', version: '1.0.0'}, {tag: 'pre'}, {packageManager: npmConfig})));
@@ -302,7 +302,7 @@ test.serial('should not fail when prerelease version of private package without 
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+	command: 'git ls-remote --tags origin v2.0.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('2.0.0-1', {name: 'test', version: '1.0.0', private: true}, {}, {packageManager: npmConfig})));
@@ -315,8 +315,8 @@ test.serial('should fail when git tag already exists', createFixture, [{
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
-	stdout: 'vvb',
+	command: 'git ls-remote --tags origin v2.0.0',
+	stdout: 'foobar\trefs/tags/v2.0.0',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.throwsAsync(
 		run(prerequisiteTasks('2.0.0', {name: 'test', version: '1.0.0'}, {}, {packageManager: npmConfig})),
@@ -333,7 +333,7 @@ test.serial('checks should pass', createFixture, [{
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+	command: 'git ls-remote --tags origin v2.0.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('2.0.0', {name: 'test', version: '1.0.0'}, {}, {packageManager: npmConfig})));
@@ -346,7 +346,7 @@ test.serial('should skip authentication check when OIDC is detected', createFixt
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+	command: 'git ls-remote --tags origin v2.0.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	process.env.NODE_ENV = 'P';
@@ -376,7 +376,7 @@ test.serial('should fail when dropping Node.js support in a minor release', crea
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.1.0',
+	command: 'git ls-remote --tags origin v1.1.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.throwsAsync(
@@ -397,7 +397,7 @@ test.serial('should fail when dropping Node.js support in a patch release', crea
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.0.1',
+	command: 'git ls-remote --tags origin v1.0.1',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.throwsAsync(
@@ -418,7 +418,7 @@ test.serial('should not fail when dropping Node.js support in a major release', 
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0',
+	command: 'git ls-remote --tags origin v2.0.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('2.0.0', {name: 'test', version: '1.0.0', engines: {node: '>=18'}}, {}, {packageManager: npmConfig})));
@@ -434,7 +434,7 @@ test.serial('should not fail when dropping Node.js support in a premajor release
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v2.0.0-0',
+	command: 'git ls-remote --tags origin v2.0.0-0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('2.0.0-0', {name: 'test', version: '1.0.0', engines: {node: '>=18'}}, {tag: 'next'}, {packageManager: npmConfig})));
@@ -450,7 +450,7 @@ test.serial('should not fail when dropping Node.js support in a pre-1.0.0 minor 
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v0.2.0',
+	command: 'git ls-remote --tags origin v0.2.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('0.2.0', {name: 'test', version: '0.1.0', engines: {node: '>=18'}}, {}, {packageManager: npmConfig})));
@@ -466,7 +466,7 @@ test.serial('should not fail when engines.node was not previously set', createFi
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.1.0',
+	command: 'git ls-remote --tags origin v1.1.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('1.1.0', {name: 'test', version: '1.0.0', engines: {node: '>=18'}}, {}, {packageManager: npmConfig})));
@@ -483,7 +483,7 @@ test.serial('should not fail when first publishing a package', createFixture, [{
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.0.0',
+	command: 'git ls-remote --tags origin v1.0.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('1.0.0', {name: 'test', version: '0.0.0', engines: {node: '>=18'}}, {}, {packageManager: npmConfig})));
@@ -499,7 +499,7 @@ test.serial('should not fail when local package has no engines.node', createFixt
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.1.0',
+	command: 'git ls-remote --tags origin v1.1.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('1.1.0', {name: 'test', version: '1.0.0'}, {}, {packageManager: npmConfig})));
@@ -512,7 +512,7 @@ test.serial('private package: should disable task checking for Node.js engine su
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.1.0',
+	command: 'git ls-remote --tags origin v1.1.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	const package_ = {
@@ -537,7 +537,7 @@ test.serial('should not fail when Node.js minimum version stays the same', creat
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.1.0',
+	command: 'git ls-remote --tags origin v1.1.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('1.1.0', {name: 'test', version: '1.0.0', engines: {node: '>=18'}}, {}, {packageManager: npmConfig})));
@@ -553,7 +553,7 @@ test.serial('should not fail when Node.js minimum version is lowered', createFix
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.1.0',
+	command: 'git ls-remote --tags origin v1.1.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.notThrowsAsync(run(prerequisiteTasks('1.1.0', {name: 'test', version: '1.0.0', engines: {node: '>=16'}}, {}, {packageManager: npmConfig})));
@@ -569,7 +569,7 @@ test.serial('should fail when dropping Node.js support in a preminor release', c
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.1.0-0',
+	command: 'git ls-remote --tags origin v1.1.0-0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.throwsAsync(
@@ -590,7 +590,7 @@ test.serial('should fail when dropping Node.js support in a prepatch release', c
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.0.1-0',
+	command: 'git ls-remote --tags origin v1.0.1-0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.throwsAsync(
@@ -611,7 +611,7 @@ test.serial('should fail when dropping Node.js support in a prerelease release',
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.0.0-1',
+	command: 'git ls-remote --tags origin v1.0.0-1',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	await t.throwsAsync(
@@ -629,7 +629,7 @@ test.serial('yolo mode: should disable task checking for Node.js engine support 
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.1.0',
+	command: 'git ls-remote --tags origin v1.1.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	const package_ = {
@@ -656,7 +656,7 @@ test.serial('external registry: should skip engine check when registry returns e
 	command: 'git config user.email',
 	stdout: 'test@example.com',
 }, {
-	command: 'git rev-parse --quiet --verify refs/tags/v1.1.0',
+	command: 'git ls-remote --tags origin v1.1.0',
 	stdout: '',
 }], async ({t, testedModule: prerequisiteTasks}) => {
 	const package_ = {


### PR DESCRIPTION
Instead of fetching the entire remote, if we want to check for the existence of a tag, we can query the remote directly for that tag. That's more efficient especially for large repos.

<!--

Thanks for submitting a pull request 🙌

**Note:** Please don't create a pull request which has significant changes (i.e. adds new functionality or modifies existing one in a non-trivial way) without creating an issue first.

Try to limit the scope of your pull request and provide a general description of the changes. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
