### PR TITLE
Skip missing entry points for lifecycle-built packages

### DIFF
--- a/source/npm/util.js
+++ b/source/npm/util.js
@@ -210,6 +210,7 @@ export const getFilesToBePacked = async rootDirectory => {
 		'--dry-run',
 		'--json',
 		'--silent',
+		'--ignore-scripts',
 		// TODO: Remove this once [npm/cli#7354](https://github.com/npm/cli/issues/7354) is resolved.
 		'--foreground-scripts=false',
 	], {cwd: rootDirectory});
@@ -224,6 +225,21 @@ export const getFilesToBePacked = async rootDirectory => {
 	} catch (error) {
 		throw new Error('Failed to parse output of npm pack', {cause: error});
 	}
+};
+
+const hasPackLifecycleScript = package_ => {
+	const {scripts} = package_;
+
+	if (typeof scripts !== 'object' || scripts === null) {
+		return false;
+	}
+
+	return [
+		'prepare',
+		'prepack',
+		'prepublish',
+		'prepublishOnly',
+	].some(scriptName => typeof scripts[scriptName] === 'string');
 };
 
 const isValidEntryPoint = value => typeof value === 'string' && !value.includes('*');
@@ -295,6 +311,10 @@ export const verifyPackageEntryPoints = async (package_, rootDirectory) => {
 	}
 
 	if (missingEntryPoints.length > 0) {
+		if (hasPackLifecycleScript(package_)) {
+			return;
+		}
+
 		const missing = missingEntryPoints.map(({field, path: entryPath}) => `  "${field}": ${entryPath}`).join('\n');
 		throw new Error(`Missing entry points in published files:\n${missing}\n\nEnsure these files exist and are included in the "files" field.`);
 	}

--- a/test/fixtures/files/failing-prepack-script/index.js
+++ b/test/fixtures/files/failing-prepack-script/index.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/test/fixtures/files/failing-prepack-script/package.json
+++ b/test/fixtures/files/failing-prepack-script/package.json
@@ -3,6 +3,6 @@
 	"version": "0.0.0",
 	"files": ["index.js"],
 	"scripts": {
-		"prepare": "echo '[build] compiling'"
+		"prepack": "exit 1"
 	}
 }

--- a/test/fixtures/files/prepack-generated-entry-point/package.json
+++ b/test/fixtures/files/prepack-generated-entry-point/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "prepack-generated-entry-point",
+	"version": "0.0.0",
+	"main": "dist/index.js",
+	"files": ["dist"],
+	"scripts": {
+		"prepack": "node --input-type=module -e \"import fs from 'node:fs'; fs.mkdirSync('dist', {recursive: true}); fs.writeFileSync('dist/index.js', 'export default 1;\\n');\""
+	}
+}

--- a/test/npm/util/entry-points.js
+++ b/test/npm/util/entry-points.js
@@ -191,3 +191,14 @@ test('verifyPackageEntryPoints - valid entry points', async t => {
 
 	await t.notThrowsAsync(npm.verifyPackageEntryPoints({main: 'index.js'}, fixtureDirectory));
 });
+
+test('verifyPackageEntryPoints - skipped when prepack script may generate files', async t => {
+	const fixtureDirectory = getFixture('prepack-generated-entry-point');
+
+	await t.notThrowsAsync(npm.verifyPackageEntryPoints({
+		main: 'dist/index.js',
+		scripts: {
+			prepack: 'build',
+		},
+	}, fixtureDirectory));
+});

--- a/test/npm/util/packed-files.js
+++ b/test/npm/util/packed-files.js
@@ -74,3 +74,7 @@ test('doesn\'t show files in .github', verifyPackedFiles, 'dot-github', [
 test('handles prepare script output (e.g., Husky)', verifyPackedFiles, 'prepare-script', [
 	'index.js',
 ]);
+
+test('ignores failing prepack script', verifyPackedFiles, 'failing-prepack-script', [
+	'index.js',
+]);


### PR DESCRIPTION
Keep `npm pack --dry-run` script-free when collecting packed files so prerequisite checks do not fail on broken lifecycle hooks or noisy script output.

Still run entry-point validation against that stable packlist, but only skip the failure when an entry point is missing and the package declares pack-related lifecycle scripts. That preserves validation for packages whose entry points are already present without scripts, while avoiding false negatives for packages that generate publishable files during `prepare` or `prepack`.

Fixes #780