### PR TITLE
Add --no-workspaces to npm version for yarn berry

### DIFF
--- a/source/package-manager/configs.js
+++ b/source/package-manager/configs.js
@@ -43,8 +43,12 @@ export const yarnBerryConfig = {
 	id: 'yarn-berry',
 	installCommand: ['yarn', ['install', '--immutable']],
 	installCommandNoLockfile: ['yarn', ['install']],
-	// Yarn berry doesn't support git committing/tagging, so we use npm instead
-	versionCommand: version => ['npm', ['version', version]],
+	// Yarn berry doesn't support git committing/tagging, so we use npm instead.
+	// `--no-workspaces` is needed because npm 11 auto-detects the workspace
+	// context when run inside a monorepo member, causing `npm version` to
+	// fail with EUNSUPPORTEDPROTOCOL on `workspace:*` deps. The flag is a
+	// no-op for single-package yarn-berry repos.
+	versionCommand: version => ['npm', ['version', '--no-workspaces', version]],
 	tagVersionPrefixCommand: ['yarn', ['config', 'get', 'version-tag-prefix']],
 	// Yarn berry offloads publishing to npm, e.g. `yarn npm publish x.y.z`
 	publishCommand: arguments_ => ['yarn', ['npm', ...arguments_]],


### PR DESCRIPTION
## What

Append `--no-workspaces` to the `npm version` call used by `yarnBerryConfig.versionCommand`.

## Why

When releasing a yarn-berry workspace member, npm 11 auto-detects the workspace context from the cwd. np uses `npm version` to bump the version (since yarn berry can't commit/tag), and that command runs `npm install` internally under the inherited workspace context. With `workspace:*` deps in sibling packages, this fails:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

…which means `np` cannot release any package inside a yarn-berry monorepo on npm 11.

`--no-workspaces` opts out of the workspace context for that single `npm version` invocation. It is a no-op for single-package yarn-berry repos, so the change is safe across both shapes.

## Repro

In a yarn-berry monorepo where one member depends on another via `workspace:*`:

```sh
cd modules/some-package
npx np patch
# fails at "Bumping version" with EUNSUPPORTEDPROTOCOL
```

After this change, the bump succeeds.

## Notes

- Tested against npm 11.6.2 and yarn 4.0.2.
- All existing `test/package-manager.js` tests still pass.