### PR TITLE
Add --allow-dirty flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ $ np --help
   Options
     --any-branch            Allow publishing from any branch
     --branch                Name of the release branch (default: main | master)
+    --allow-dirty           Allow publishing when the working tree is dirty
     --no-cleanup            Skips np's node_modules cleanup step before install
     --no-tests              Skips tests
     --yolo                  Skips cleanup and testing

--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -29,6 +29,7 @@ const cli = meow(`
 	Options
 	  --any-branch           Allow publishing from any branch
 	  --branch               Name of the release branch (default: main | master)
+	  --allow-dirty          Allow publishing when the working tree is dirty
 	  --no-cleanup           Skips np's node_modules cleanup step before install
 	  --no-tests             Skips tests
 	  --yolo                 Skips cleanup and testing
@@ -63,6 +64,9 @@ const cli = meow(`
 		},
 		branch: {
 			type: 'string',
+		},
+		allowDirty: {
+			type: 'boolean',
 		},
 		cleanup: {
 			type: 'boolean',
@@ -178,10 +182,16 @@ async function getOptions() {
 	const version = flags.releaseDraftOnly ? package_.version : cli.input.at(0);
 
 	const branch = flags.branch ?? await git.defaultBranch();
+
 	if (!flags.releaseDraftOnly) {
 		// Keep obvious Git failures ahead of the wizard, but do not replace the later Git task.
 		// The publish flow still needs a final check in case the repo changes while the user is prompting or logging in.
-		await verifyGitTasks({anyBranch: flags.anyBranch, branch, remote: flags.remote});
+		await verifyGitTasks({
+			anyBranch: flags.anyBranch,
+			allowDirty: flags.allowDirty,
+			branch,
+			remote: flags.remote,
+		});
 	}
 
 	const options = await ui({
@@ -201,6 +211,23 @@ async function getOptions() {
 	};
 }
 
+async function verifyPublishAuth(package_) {
+	const externalRegistry = npm.isExternalRegistry(package_)
+		? package_.publishConfig.registry
+		: false;
+
+	try {
+		await npm.username({externalRegistry});
+	} catch (error) {
+		if (error.isNotLoggedIn && isInteractive()) {
+			console.log('\nYou must be logged in to publish. Running `npm login`...\n');
+			await npm.login({externalRegistry});
+		} else {
+			throw error;
+		}
+	}
+}
+
 try {
 	const {options, projectDirectory, rootDirectory, package_} = await getOptions();
 
@@ -210,24 +237,10 @@ try {
 
 	// Check authentication early, before Listr starts (so login can be interactive)
 	if (options.runPublish) {
-		// Skip auth check if OIDC is available (will be handled by npm publish itself)
 		if (getOidcProvider()) {
 			console.log('OIDC authentication detected - skipping auth check');
 		} else {
-			const externalRegistry = npm.isExternalRegistry(package_)
-				? package_.publishConfig.registry
-				: false;
-
-			try {
-				await npm.username({externalRegistry});
-			} catch (error) {
-				if (error.isNotLoggedIn && isInteractive()) {
-					console.log('\nYou must be logged in to publish. Running `npm login`...\n');
-					await npm.login({externalRegistry});
-				} else {
-					throw error;
-				}
-			}
+			await verifyPublishAuth(package_);
 		}
 	}
 

--- a/source/git-tasks.js
+++ b/source/git-tasks.js
@@ -21,6 +21,13 @@ const createGitTasks = options => {
 		tasks.shift();
 	}
 
+	if (options.allowDirty) {
+		const index = tasks.findIndex(task => task.title === 'Check local working tree');
+		if (index !== -1) {
+			tasks.splice(index, 1);
+		}
+	}
+
 	return tasks;
 };
 
@@ -29,7 +36,10 @@ export const verifyGitTasks = async options => {
 		await git.verifyCurrentBranchIsReleaseBranch(options.branch);
 	}
 
-	await git.verifyWorkingTreeIsClean();
+	if (!options.allowDirty) {
+		await git.verifyWorkingTreeIsClean();
+	}
+
 	if (options.remote) {
 		await git.verifyRemoteIsValid(options.remote);
 	} else if (

--- a/source/index.js
+++ b/source/index.js
@@ -177,10 +177,12 @@ const np = async (input = 'patch', {packageManager, ...rawOptions}, {package_, p
 						return exec(...getInstallCommand(), {cwd: projectDirectory});
 					},
 				},
-				{
-					title: 'Checking working tree is still clean', // If lockfile was out of date and tracked by git, this will fail
-					task: () => git.verifyWorkingTreeIsClean(),
-				},
+				...options.allowDirty
+					? []
+					: [{
+						title: 'Checking working tree is still clean', // If lockfile was out of date and tracked by git, this will fail
+						task: () => git.verifyWorkingTreeIsClean(),
+					}],
 			]),
 		},
 		{

--- a/test/cli.js
+++ b/test/cli.js
@@ -22,6 +22,7 @@ test('flags: --help', cliPasses, cli, '--help', [
 	'Options',
 	'--any-branch           Allow publishing from any branch',
 	'--branch               Name of the release branch (default: main | master)',
+	'--allow-dirty          Allow publishing when the working tree is dirty',
 	'--no-cleanup           Skips np\'s node_modules cleanup step before install',
 	'--no-tests             Skips tests',
 	'--yolo                 Skips cleanup and testing',
@@ -139,7 +140,12 @@ test.serial('cli runs git preflight before prompting', async t => {
 		},
 	});
 
-	t.true(verifyGitTasksStub.calledOnceWithExactly({anyBranch: undefined, branch: 'main', remote: undefined}));
+	t.true(verifyGitTasksStub.calledOnceWithExactly({
+		anyBranch: undefined,
+		allowDirty: undefined,
+		branch: 'main',
+		remote: undefined,
+	}));
 	t.true(uiStub.notCalled);
 	t.true(gracefulExitStub.calledOnceWithExactly(1));
 
@@ -163,7 +169,12 @@ test.serial('cli continues to the publish flow after successful git preflight', 
 		},
 	});
 
-	t.true(verifyGitTasksStub.calledOnceWithExactly({anyBranch: undefined, branch: 'main', remote: undefined}));
+	t.true(verifyGitTasksStub.calledOnceWithExactly({
+		anyBranch: undefined,
+		allowDirty: undefined,
+		branch: 'main',
+		remote: undefined,
+	}));
 	t.true(uiStub.calledOnce);
 	t.true(npStub.calledOnce);
 	t.false('skipGitTasks' in npStub.firstCall.args[1]);

--- a/test/tasks/git-tasks.js
+++ b/test/tasks/git-tasks.js
@@ -79,6 +79,29 @@ test.serial('should fail when local working tree modified', createFixture, [
 	assertTaskFailed(t, 'Check local working tree');
 });
 
+test.serial('should not fail when local working tree modified and allow-dirty is enabled', createFixture, [
+	{
+		command: 'git symbolic-ref --short HEAD',
+		stdout: 'master',
+	},
+	{
+		command: 'git rev-parse @{u}',
+		exitCode: 0,
+	},
+	{
+		command: 'git fetch --dry-run',
+		exitCode: 0,
+	},
+	{
+		command: 'git rev-list --count --left-only @{u}...HEAD',
+		stdout: '0',
+	},
+], async ({t, testedModule: gitTasks}) => {
+	await t.notThrowsAsync(run(gitTasks({branch: 'master', allowDirty: true})));
+
+	assertTaskDoesntExist(t, 'Check local working tree');
+});
+
 test.serial('should not fail when no remote set up', createFixture, [
 	{
 		command: 'git symbolic-ref --short HEAD',
@@ -204,6 +227,39 @@ test.serial('preflight should validate remote before checking remote history', c
 		testedModule.verifyGitTasks({branch: 'master'}),
 		{message: 'Git fatal error: could not read from remote repository'},
 	);
+});
+
+test.serial('preflight should skip working tree check with allowDirty', createFixture, [
+	{
+		command: 'git symbolic-ref --short HEAD',
+		stdout: 'master',
+	},
+	{
+		command: 'git status --short --branch --porcelain',
+		stdout: '## master...origin/master',
+	},
+	{
+		command: 'git config branch.master.remote',
+		stdout: 'origin',
+	},
+	{
+		command: 'git ls-remote origin HEAD',
+		exitCode: 0,
+	},
+	{
+		command: 'git rev-parse @{u}',
+		exitCode: 0,
+	},
+	{
+		command: 'git fetch --dry-run',
+		exitCode: 0,
+	},
+	{
+		command: 'git rev-list --count --left-only @{u}...HEAD',
+		stdout: '0',
+	},
+], async ({t, testedModule}) => {
+	await t.notThrowsAsync(testedModule.verifyGitTasks({branch: 'master', allowDirty: true}));
 });
 
 test.serial('preflight should skip upstream probe on detached head with anyBranch', createFixture, [


### PR DESCRIPTION
I have the feeling this will create some controversy, but hear me out. I'm fully aware that ignoring a dirty git state can introduce some unwanted behaviour; files that are not tracked could still end up in a published package, which likely nobody ever wants to happen. However, the situation is very different when working in a monorepo that contains multiple packages. A dirty state in package B would prevent package A being published. This flag helps working around that.

Let me know what you think or feel free to close this.