### PR TITLE
Ensure CLI cursor visible after publishing

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import process from 'node:process';
 import {execa} from 'execa';
 import {deleteAsync} from 'del';
 // NOTE: We intentionally use the original `listr` package instead of `listr2`.
@@ -30,6 +31,12 @@ import {findLockfile, printCommand} from './package-manager/index.js';
 import * as util from './util.js';
 import * as git from './git-util.js';
 import * as npm from './npm/util.js';
+
+const restoreCursor = () => {
+	if (process.stderr.isTTY) {
+		process.stderr.write('\u001B[?25h');
+	}
+};
 
 /** @type {(cmd: string, args: string[], options?: import('execa').Options) => any} */
 const exec = (command, arguments_, options) => {
@@ -309,6 +316,10 @@ const np = async (input = 'patch', {packageManager, ...rawOptions}, {package_, p
 	}
 
 	await tasks.run();
+
+	// Listr-update-renderer calls logUpdate.clear() on successful clearOutput,
+	// which skips logUpdate.done() and can leave the terminal cursor hidden.
+	restoreCursor();
 
 	if (pushedObjects) {
 		console.error(`\n${logSymbols.error} ${pushedObjects.reason}`);

--- a/test/index.js
+++ b/test/index.js
@@ -206,6 +206,43 @@ test('rollback is called when publish fails', async t => {
 	t.true(removeLastCommitStub.calledOnce, 'removeLastCommit should be called once');
 });
 
+test('restores cursor after successful publish', async t => {
+	const stderrWriteStub = sinon.stub().returns(true);
+
+	/** @type {typeof np} */
+	const npMock = await esmock('../source/index.js', {
+		'node:process': {
+			stderr: {
+				isTTY: true,
+				write: stderrWriteStub,
+			},
+		},
+		del: {deleteAsync: sinon.stub()},
+		execa: {execa: sinon.stub().returns(fakeExecaReturn())},
+		'../source/prerequisite-tasks.js': sinon.stub(),
+		'../source/git-tasks.js': sinon.stub(),
+		'../source/git-util.js': {
+			hasUpstream: sinon.stub().returns(true),
+			pushGraceful: sinon.stub(),
+			verifyWorkingTreeIsClean: sinon.stub(),
+		},
+		'../source/npm/enable-2fa.js': sinon.stub(),
+		'../source/npm/publish.js': {
+			getPackagePublishArguments: sinon.stub().returns([]),
+			runPublish: sinon.stub().returns(fakeObservableReturn()),
+		},
+	});
+
+	await npMock('1.0.0', {
+		...defaultOptions,
+		cleanup: false,
+		tests: false,
+		'2fa': false,
+	}, npPackageResult);
+
+	t.true(stderrWriteStub.calledWithExactly('\u001B[?25h'));
+});
+
 test('publish uses rootDirectory from context as cwd', async t => {
 	const contentsDirectory = path.resolve('dist');
 	const projectDirectory = path.resolve('.');


### PR DESCRIPTION
The cursor can't be restored after publishing.

BTW, this problem has existed since I started using `np`. I'm curious why others didn't report this bug 🤔.

### Broken path

The broken path was the successful publish path with Listr’s default renderer and `clearOutput` enabled:

1. `source/index.js` creates Listr with `clearOutput: !options.dryRun && !options.releaseDraftOnly`:
2. During rendering, `log-update` hides the cursor via `cli-cursor.hide()`.
3. On successful completion, `listr-update-renderer.end(undefined)` takes the `clearOutput` branch:
	```js
	if (this._options.clearOutput && err === undefined) {
		logUpdate.clear();
	} else {
		logUpdate.done();
	}
	```
4. `logUpdate.clear()` only clears the rendered task output. It does not restore the cursor.
5. Cursor restoration only happens in `logUpdate.done()`, but that branch is skipped on successful publish with `clearOutput`.

So the bug was not in `npm publish` itself. It was: successful Listr run + `clearOutput: true` -> `logUpdate.clear()` -> no `logUpdate.done()` -> cursor remains hidden.