### PR TITLE
Re-verify npm auth after auto-login

### DIFF
--- a/source/cli-implementation.js
+++ b/source/cli-implementation.js
@@ -201,6 +201,41 @@ async function getOptions() {
 	};
 }
 
+const ensureAuthenticated = async package_ => {
+	// Skip auth check if OIDC is available (will be handled by npm publish itself)
+	if (getOidcProvider()) {
+		console.log('OIDC authentication detected - skipping auth check');
+		return;
+	}
+
+	// Use the exact publish registry (if any) so this check can't disagree with the prerequisite auth check. See #764.
+	const externalRegistry = package_.publishConfig?.registry;
+
+	try {
+		await npm.username({externalRegistry});
+		return;
+	} catch (error) {
+		if (!error.isNotLoggedIn || !isInteractive()) {
+			throw error;
+		}
+	}
+
+	console.log('\nYou must be logged in to publish. Running `npm login`...\n');
+	await npm.login({externalRegistry});
+
+	// `npm login` writes a fresh session token to the user `.npmrc`, but a project-level `.npmrc` with a stale or revoked token takes precedence and keeps `npm whoami` failing. Re-verify so we fail with a clear reason instead of looping on the generic prerequisite-task error.
+	try {
+		await npm.username({externalRegistry});
+	} catch (error) {
+		// Only the still-not-logged-in case points to the stale-token cause; surface other errors (e.g. a network timeout) as-is.
+		if (!error.isNotLoggedIn) {
+			throw error;
+		}
+
+		throw new Error('Still not authenticated after `npm login`. A project-level `.npmrc` may hold a stale or revoked token that overrides your login. Check it for outdated `_authToken` entries.');
+	}
+};
+
 try {
 	const {options, projectDirectory, rootDirectory, package_} = await getOptions();
 
@@ -210,25 +245,7 @@ try {
 
 	// Check authentication early, before Listr starts (so login can be interactive)
 	if (options.runPublish) {
-		// Skip auth check if OIDC is available (will be handled by npm publish itself)
-		if (getOidcProvider()) {
-			console.log('OIDC authentication detected - skipping auth check');
-		} else {
-			const externalRegistry = npm.isExternalRegistry(package_)
-				? package_.publishConfig.registry
-				: false;
-
-			try {
-				await npm.username({externalRegistry});
-			} catch (error) {
-				if (error.isNotLoggedIn && isInteractive()) {
-					console.log('\nYou must be logged in to publish. Running `npm login`...\n');
-					await npm.login({externalRegistry});
-				} else {
-					throw error;
-				}
-			}
-		}
+		await ensureAuthenticated(package_);
 	}
 
 	console.log(); // Prints a newline for readability

--- a/source/prerequisite-tasks.js
+++ b/source/prerequisite-tasks.js
@@ -34,6 +34,7 @@ const prerequisiteTasks = (input, package_, options, {packageManager, rootDirect
 				}
 			},
 			async task() {
+				// Use the exact publish registry (if any) so this check can't disagree with the early auth check. See #764.
 				const externalRegistry = package_.publishConfig?.registry;
 				const username = await npm.username({externalRegistry});
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -169,3 +169,68 @@ test.serial('cli continues to the publish flow after successful git preflight', 
 	t.false('skipGitTasks' in npStub.firstCall.args[1]);
 	t.true(gracefulExitStub.notCalled);
 });
+
+const notLoggedInError = () => Object.assign(new Error('You must be logged in. Use `npm login` and try again.'), {isNotLoggedIn: true});
+
+test.serial('cli auto-runs `npm login` and re-verifies after a successful login', async t => {
+	const usernameStub = sinon.stub();
+	usernameStub.onFirstCall().rejects(notLoggedInError());
+	usernameStub.onSecondCall().resolves('sindresorhus');
+	const loginStub = sinon.stub().resolves();
+	const npStub = sinon.stub().resolves({name: 'test-package', version: '1.0.1'});
+	const gracefulExitStub = sinon.stub();
+	const consoleLogStub = sinon.stub(console, 'log');
+
+	await loadCliImplementation({
+		meow: {default: sinon.stub().returns({input: ['patch'], flags: {publish: true}, pkg: npPackage})},
+		'is-interactive': {default: sinon.stub().returns(true)},
+		'../source/npm/util.js': {
+			isExternalRegistry: sinon.stub().returns(false),
+			isPackageNameAvailable: sinon.stub().resolves({isAvailable: false, isUnknown: false}),
+			username: usernameStub,
+			login: loginStub,
+		},
+		'../source/ui.js': {default: sinon.stub().callsFake(async options => ({...options, confirm: true, version: '1.0.1'}))},
+		'../source/index.js': {default: npStub},
+		'exit-hook': {gracefulExit: gracefulExitStub},
+	});
+
+	t.true(loginStub.calledOnce);
+	t.true(usernameStub.calledTwice);
+	t.true(npStub.calledOnce);
+
+	consoleLogStub.restore();
+});
+
+test.serial('cli fails with an actionable error when still not authenticated after `npm login`', async t => {
+	const usernameStub = sinon.stub().rejects(notLoggedInError());
+	const loginStub = sinon.stub().resolves();
+	const npStub = sinon.stub().resolves({name: 'test-package', version: '1.0.1'});
+	const gracefulExitStub = sinon.stub();
+	const consoleLogStub = sinon.stub(console, 'log');
+	const consoleErrorStub = sinon.stub(console, 'error');
+
+	await loadCliImplementation({
+		meow: {default: sinon.stub().returns({input: ['patch'], flags: {publish: true}, pkg: npPackage})},
+		'is-interactive': {default: sinon.stub().returns(true)},
+		'../source/npm/util.js': {
+			isExternalRegistry: sinon.stub().returns(false),
+			isPackageNameAvailable: sinon.stub().resolves({isAvailable: false, isUnknown: false}),
+			username: usernameStub,
+			login: loginStub,
+		},
+		'../source/ui.js': {default: sinon.stub().callsFake(async options => ({...options, confirm: true, version: '1.0.1'}))},
+		'../source/index.js': {default: npStub},
+		'exit-hook': {gracefulExit: gracefulExitStub},
+	});
+
+	t.true(loginStub.calledOnce);
+	t.true(usernameStub.calledTwice);
+	t.true(npStub.notCalled);
+	t.true(gracefulExitStub.calledOnceWithExactly(1));
+	t.true(consoleErrorStub.calledOnce);
+	t.true(consoleErrorStub.firstCall.firstArg.includes('Still not authenticated after `npm login`'));
+
+	consoleLogStub.restore();
+	consoleErrorStub.restore();
+});


### PR DESCRIPTION
After auto-running `npm login`, re-check `npm whoami` and fail with a clear, actionable error if still not authenticated, instead of silently continuing to a second whoami check that re-throws a generic message. The common cause is a project-level `.npmrc` holding a stale or revoked token that overrides the session token `npm login` writes to the user `.npmrc`.

Fixes #795